### PR TITLE
Add CI, k8s manifests and monitoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "work"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [bases_de_datos, asistencia, nomina]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: |
+          cd ${{ matrix.service }}
+          npm ci
+      - name: Run tests
+        run: |
+          cd ${{ matrix.service }}
+          npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Node dependencies
+node_modules/
+
+# Environment files
+.env
+*.env
+*/.env
+.env.*
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Local data
+postgres-data/
+redis-data/
+
+# macOS
+.DS_Store

--- a/asistencia/.env
+++ b/asistencia/.env
@@ -1,4 +1,0 @@
-PORT=3003
-BASES_DE_DATOS_URL=http://bases-de-datos:3000
-API_KEY=midiosclave123
-

--- a/asistencia/.env.example
+++ b/asistencia/.env.example
@@ -1,0 +1,3 @@
+PORT=3003
+BASES_DE_DATOS_URL=http://bases_de_datos:3001
+API_KEY=change-me

--- a/bases_de_datos/.env.example
+++ b/bases_de_datos/.env.example
@@ -1,6 +1,5 @@
 DB_USER=admin
-DB_PASSWORD=secret
+DB_PASSWORD=change-me
 DB_NAME=saas_db
 DB_HOST=postgres
 DB_PORT=5432
-

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,9 @@
+# Kubernetes Manifests
+
+This directory contains basic Kubernetes manifests to deploy the stack.
+Secrets referenced in the deployments should be created separately with your own values.
+
+Apply all manifests with:
+```bash
+kubectl apply -f .
+```

--- a/k8s/asistencia.yaml
+++ b/k8s/asistencia.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: asistencia
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: asistencia
+  template:
+    metadata:
+      labels:
+        app: asistencia
+    spec:
+      containers:
+        - name: asistencia
+          image: your-registry/asistencia:latest
+          envFrom:
+            - secretRef:
+                name: asistencia-secret
+          ports:
+            - containerPort: 3003
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: asistencia
+spec:
+  selector:
+    app: asistencia
+  ports:
+    - port: 3003
+      targetPort: 3003

--- a/k8s/bases-de-datos.yaml
+++ b/k8s/bases-de-datos.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bases-de-datos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bases-de-datos
+  template:
+    metadata:
+      labels:
+        app: bases-de-datos
+    spec:
+      containers:
+        - name: bases-de-datos
+          image: your-registry/bases_de_datos:latest
+          envFrom:
+            - secretRef:
+                name: bases-de-datos-secret
+          ports:
+            - containerPort: 3001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bases-de-datos
+spec:
+  selector:
+    app: bases-de-datos
+  ports:
+    - port: 3001
+      targetPort: 3001

--- a/k8s/nomina.yaml
+++ b/k8s/nomina.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nomina
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nomina
+  template:
+    metadata:
+      labels:
+        app: nomina
+    spec:
+      containers:
+        - name: nomina
+          image: your-registry/nomina:latest
+          envFrom:
+            - secretRef:
+                name: nomina-secret
+          ports:
+            - containerPort: 3002
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nomina
+spec:
+  selector:
+    app: nomina
+  ports:
+    - port: 3002
+      targetPort: 3002

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17
+          env:
+            - name: POSTGRES_DB
+              value: saas_db
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: password
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgres-data
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:alpine
+          args: ["redis-server", "--requirepass", "$(REDIS_PASSWORD)"]
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: password
+          ports:
+            - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,4 @@
+# Monitoring Stack
+
+This folder contains a simple Prometheus and Grafana setup for local monitoring.
+Run `docker-compose up` in this directory to start both services.

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,7 @@
+scrape_configs:
+  - job_name: 'saas'
+    static_configs:
+      - targets:
+          - 'bases_de_datos:3001'
+          - 'asistencia:3003'
+          - 'nomina:3002'

--- a/nomina/.env.example
+++ b/nomina/.env.example
@@ -1,4 +1,4 @@
-JWT_SECRET=your-secret-key-here
+JWT_SECRET=change-me
 # Server Configuration
 PORT=3002
 NODE_ENV=development
@@ -9,7 +9,7 @@ BASES_DE_DATOS_URL=http://bases_de_datos:3001
 # Redis Configuration (for sessions)
 REDIS_HOST=redis
 REDIS_PORT=6379
-REDIS_PASSWORD=redis_secret
+REDIS_PASSWORD=change-me
 
 # Security
 CORS_ORIGIN=http://localhost:3000


### PR DESCRIPTION
## Summary
- add a `.gitignore` to avoid committing environment files
- move environment secrets to `*.env.example` files
- create GitHub Actions workflow for running service tests
- provide monitoring stack with Prometheus and Grafana
- add Kubernetes manifests for all services

## Testing
- `npm test` in `bases_de_datos`
- `npm test` in `asistencia`
- `npm test` in `nomina`


------
https://chatgpt.com/codex/tasks/task_e_68522a2128c4832983462eac7df0ceed