### PR TITLE
feat: refresh landing page with new blue palette

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,7 @@ import { createClient } from '../lib/supabase/client'
 import { createContext, useState, useEffect } from 'react'
 import { AuthProvider } from '../lib/auth'
 import '../styles/globals.css'
+import '../styles/landing.css'
 
 // Create a context for Supabase client (using new SSR client)
 export const SupabaseContext = createContext<any>(null)

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -1,134 +1,84 @@
-import { useState } from 'react'
 import Head from 'next/head'
 import Link from 'next/link'
+import {
+  IdentificationIcon,
+  CalculatorIcon,
+  ChartBarIcon,
+} from '@heroicons/react/24/outline'
 
-const content = {
-  en: {
-    hero: {
-      candidate: {
-        title: 'Find your next opportunity',
-        subtitle: 'Connect with top companies and grow your career',
-      },
-      company: {
-        title: 'Hire great talent',
-        subtitle: 'Streamline your recruitment with modern tools',
-      },
-    },
+const services = [
+  {
+    title: 'Asistencia Inteligente',
+    description:
+      'Registro por DNI (5 dígitos) + detección de llegadas tarde → 95 % menos errores',
+    icon: IdentificationIcon,
   },
-  es: {
-    hero: {
-      candidate: {
-        title: 'Encuentra tu próxima oportunidad',
-        subtitle: 'Conecta con empresas líderes y crece en tu carrera',
-      },
-      company: {
-        title: 'Contrata gran talento',
-        subtitle: 'Optimiza tu reclutamiento con herramientas modernas',
-      },
-    },
+  {
+    title: 'Planilla Automática',
+    description:
+      'Cálculo con IHSS, RAP e ISR incluidos → 80 % menos tiempo y PDF listos para firma',
+    icon: CalculatorIcon,
   },
-}
+  {
+    title: 'Analytics en Tiempo Real',
+    description:
+      'Dashboard con métricas de puntualidad, costo de nómina y reportes exportables',
+    icon: ChartBarIcon,
+  },
+]
 
 export default function LandingPage() {
-  const [language, setLanguage] = useState<'en' | 'es'>('en')
-  const [userType, setUserType] = useState<'candidate' | 'company'>('candidate')
-  const [darkMode, setDarkMode] = useState(false)
-
-  const t = content[language]
-
   return (
-    <div className={`min-h-screen bg-[var(--landing-bg)] text-[var(--landing-secondary)] ${darkMode ? 'dark' : ''}`}>
+    <div className="landing min-h-screen bg-[var(--bg-hero)] text-gray-800 dark:text-gray-100">
       <Head>
-        <title>{`Humano SISU - ${language === 'en' ? 'Landing Page' : 'Página de Inicio'}`}</title>
+        <title>Humano SISU - Landing</title>
         <meta
           name="description"
-          content="HR platform landing page with dual user experience"
+          content="Convierte tu CV en un imán para reclutadores"
         />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
 
-      {/* Navigation Header */}
-      <header className="sticky top-0 bg-white dark:bg-gray-800 shadow-md z-50">
-        <div className="container mx-auto px-4 py-4 flex justify-between items-center">
-          <div className="text-2xl font-bold text-[var(--landing-primary)]">
-            Humano SISU
-          </div>
-          
-          <div className="flex items-center space-x-4">
-            {/* Language Toggle */}
-            <button
-              onClick={() => setLanguage(language === 'en' ? 'es' : 'en')}
-              className="px-3 py-1 border rounded hover:bg-gray-100 dark:hover:bg-gray-700"
-            >
-              {language === 'en' ? 'ES' : 'EN'}
-            </button>
-            
-            {/* User Type Switch */}
-            <button
-              onClick={() => setUserType(userType === 'candidate' ? 'company' : 'candidate')}
-              className="px-3 py-1 border rounded hover:bg-gray-100 dark:hover:bg-gray-700"
-            >
-              {userType === 'candidate' ? 'Company View' : 'Candidate View'}
-            </button>
-            
-            {/* Dark Mode Toggle */}
-            <button
-              onClick={() => setDarkMode(!darkMode)}
-              className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
-            >
-              {darkMode ? '☀️' : '🌙'}
-            </button>
-          </div>
-        </div>
-      </header>
-
       {/* Hero Section */}
-      <main>
-        <section className="landing-section text-center bg-gradient-to-r from-[var(--landing-primary)] to-[var(--landing-secondary)] text-white">
-          <h1 className="text-4xl font-bold mb-4">
-            {t.hero[userType].title}
-          </h1>
-          <p className="mb-8 text-lg">
-            {t.hero[userType].subtitle}
-          </p>
-          <Link
-            href="/login"
-            className="inline-block px-6 py-3 bg-white text-[var(--landing-primary)] font-semibold rounded shadow hover:scale-105 transition-transform"
-          >
-            {language === 'en' ? 'Get Started' : 'Comenzar'}
-          </Link>
-        </section>
+      <section className="landing-section text-center bg-white/30 dark:bg-gray-900/30 backdrop-blur-md">
+        <h1 className="text-4xl font-bold mb-4">
+          Convierte tu CV en un imán para reclutadores
+        </h1>
+        <p className="mb-8 text-lg">
+          Ahorra 35 h/mes y elimina 95 % de errores en RR.HH.
+        </p>
+        <Link
+          href="/login"
+          className="btn-primary px-6 py-3 rounded font-semibold shadow"
+          aria-label="Comenzar"
+        >
+          Comenzar
+        </Link>
+      </section>
 
-        {/* Simple Content Section */}
-        <section className="landing-section">
-          <div className="text-center">
-            <h2 className="text-3xl font-semibold mb-8">
-              {language === 'en' ? 'Welcome to Humano SISU' : 'Bienvenido a Humano SISU'}
-            </h2>
-            <p className="text-lg mb-8">
-              {language === 'en' 
-                ? 'Your HR management platform for the modern workplace'
-                : 'Tu plataforma de gestión de RRHH para el lugar de trabajo moderno'
-              }
-            </p>
-            <div className="max-w-md mx-auto p-6 bg-white dark:bg-gray-800 rounded shadow">
-              <h3 className="text-xl font-bold mb-2 text-[var(--landing-primary)]">
-                {language === 'en' ? 'Test Controls' : 'Controles de Prueba'}
+      {/* Services Section */}
+      <section className="landing-section">
+        <h2 className="text-3xl font-semibold mb-8 text-center">
+          Nuestros Servicios
+        </h2>
+        <div className="grid gap-8 md:grid-cols-3">
+          {services.map((service) => (
+            <div
+              key={service.title}
+              className="p-6 bg-white/30 dark:bg-gray-900/30 backdrop-blur-md rounded shadow"
+            >
+              <service.icon
+                className="h-12 w-12 mx-auto text-[var(--primary)]"
+                aria-hidden="true"
+              />
+              <h3 className="text-xl font-bold mt-4 mb-2 text-center">
+                {service.title}
               </h3>
-              <p>Current Language: <strong>{language}</strong></p>
-              <p>User Type: <strong>{userType}</strong></p>
-              <p>Dark Mode: <strong>{darkMode ? 'On' : 'Off'}</strong></p>
+              <p className="text-center text-sm">{service.description}</p>
             </div>
-          </div>
-        </section>
-      </main>
-
-      {/* Footer */}
-      <footer className="bg-gray-800 text-white py-8">
-        <div className="container mx-auto px-4 text-center">
-          <p>&copy; 2025 Humano SISU. {language === 'en' ? 'All rights reserved.' : 'Todos los derechos reservados.'}</p>
+          ))}
         </div>
-      </footer>
+      </section>
     </div>
   )
 }
+

--- a/styles/landing.css
+++ b/styles/landing.css
@@ -1,22 +1,40 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap');
 
 :root {
-  --landing-primary: #4682b4; /* Steel Blue */
-  --landing-secondary: #4a5568; /* Gray */
-  --landing-bg: #f7f9fb; /* Light background */
-  --landing-accent: #ffd700; /* Yellow */
+  /* Nuevo azul profesional */
+  --primary: #3b82f6;
+  --primary-hover: #2563eb;
+  --primary-gradient: linear-gradient(135deg, #3b82f6, #2563eb);
+  --bg-hero: #f3f4f6;
 }
 
 .dark {
-  --landing-bg: #1a202c; /* Dark background */
-  --landing-primary: #ffd700; /* Accent as primary in dark mode */
-  --landing-secondary: #e2e8f0; /* Light gray text */
+  --bg-hero: #1f2937;
+  --primary: #3b82f6;
+  --primary-hover: #2563eb;
+  --primary-gradient: linear-gradient(135deg, #3b82f6, #2563eb);
 }
 
-body.landing {
+/* Tipografía para la landing */
+.landing {
   font-family: 'Montserrat', sans-serif;
 }
 
 .landing-section {
   padding: 4rem 1rem;
+}
+
+.btn-primary {
+  background: var(--primary-gradient);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: var(--primary-hover);
+}
+
+.btn-secondary {
+  border: 2px solid var(--primary);
+  color: var(--primary);
+  background: transparent;
 }


### PR DESCRIPTION
## Summary
- replace landing globals with blue palette and glass backdrop
- redesign landing hero and services copy
- hook landing styles into app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689633d296448329a934c98567b4ef54