### PR TITLE
feat(attendance): add operational dashboard

### DIFF
--- a/components/attendance/AbsenceTable.tsx
+++ b/components/attendance/AbsenceTable.tsx
@@ -1,0 +1,40 @@
+interface AbsenceRow {
+  id: string
+  name: string
+  team?: string
+}
+
+interface AbsenceTableProps {
+  data: AbsenceRow[]
+  title: string
+  onSelect?: (id: string, name: string) => void
+}
+
+export default function AbsenceTable({ data, title, onSelect }: AbsenceTableProps) {
+  return (
+    <div className="bg-gray-800 rounded p-4">
+      <h3 className="text-white font-semibold mb-2">{title}</h3>
+      <table className="w-full text-sm text-left">
+        <thead className="text-gray-300">
+          <tr>
+            <th className="py-1">Empleado</th>
+            <th className="py-1">Equipo</th>
+          </tr>
+        </thead>
+        <tbody className="text-gray-100">
+          {data.map((row) => (
+            <tr key={row.id} className="border-t border-gray-700 hover:bg-gray-700/50 cursor-pointer" onClick={() => onSelect && onSelect(row.id, row.name)}>
+              <td className="py-1">{row.name}</td>
+              <td className="py-1">{row.team || '-'}</td>
+            </tr>
+          ))}
+          {data.length === 0 && (
+            <tr>
+              <td colSpan={2} className="text-center py-4 text-gray-400">Sin datos</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/components/attendance/EmployeeDrawer.tsx
+++ b/components/attendance/EmployeeDrawer.tsx
@@ -1,0 +1,40 @@
+interface TimelineEvent {
+  ts_local: string
+  event_type: string
+  source?: string
+  justification?: string | null
+}
+
+interface EmployeeDrawerProps {
+  open: boolean
+  onClose: () => void
+  name: string
+  events: TimelineEvent[]
+}
+
+export default function EmployeeDrawer({ open, onClose, name, events }: EmployeeDrawerProps) {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50" onClick={onClose}>
+      <div className="absolute right-0 top-0 h-full w-full max-w-md bg-gray-900 p-4 overflow-y-auto" onClick={e=>e.stopPropagation()}>
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-white text-lg font-semibold">{name}</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-white">✕</button>
+        </div>
+        <ul className="space-y-2">
+          {events.map((ev, idx) => (
+            <li key={idx} className="bg-gray-800 rounded p-2 text-sm text-gray-100">
+              <div className="flex justify-between">
+                <span>{new Date(ev.ts_local).toLocaleString('es-HN')}</span>
+                <span>{ev.event_type}</span>
+              </div>
+              {ev.justification && (
+                <div className="text-xs text-gray-400">{ev.justification}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/components/attendance/ExportButton.tsx
+++ b/components/attendance/ExportButton.tsx
@@ -1,0 +1,19 @@
+interface ExportButtonProps {
+  onExport: (format: string) => Promise<void>
+}
+
+export default function ExportButton({ onExport }: ExportButtonProps) {
+  const handleExport = (format: string) => {
+    onExport(format)
+  }
+
+  return (
+    <div className="flex gap-2">
+      {['csv','xlsx','pdf'].map(f => (
+        <button key={f} onClick={() => handleExport(f)} className="bg-gray-800 text-white rounded px-3 py-2 text-sm">
+          Export {f.toUpperCase()}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/components/attendance/FiltersBar.tsx
+++ b/components/attendance/FiltersBar.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react'
+import { DateTime } from 'luxon'
+
+interface FiltersBarProps {
+  preset: string
+  onPresetChange: (p: string) => void
+  team?: string
+  onTeamChange?: (t: string) => void
+  search?: string
+  onSearchChange?: (s: string) => void
+  startDate?: string
+  endDate?: string
+  onRangeChange?: (from: string, to: string) => void
+}
+
+const presets = [
+  { label: 'Hoy', value: 'today' },
+  { label: 'Semana', value: 'week' },
+  { label: 'Quincena', value: 'fortnight' },
+  { label: 'Mes', value: 'month' },
+  { label: 'Año', value: 'year' },
+  { label: 'Custom', value: 'custom' }
+]
+
+export default function FiltersBar({
+  preset,
+  onPresetChange,
+  team = '',
+  onTeamChange,
+  search = '',
+  onSearchChange,
+  startDate,
+  endDate,
+  onRangeChange
+}: FiltersBarProps) {
+  const [localFrom, setLocalFrom] = useState(startDate || DateTime.now().toISODate())
+  const [localTo, setLocalTo] = useState(endDate || DateTime.now().toISODate())
+
+  const handleRangeChange = (from: string, to: string) => {
+    setLocalFrom(from)
+    setLocalTo(to)
+    onRangeChange && onRangeChange(from, to)
+  }
+
+  return (
+    <div className="flex flex-col gap-4 md:flex-row md:items-end">
+      <div>
+        <label className="block text-sm text-gray-300">Presets</label>
+        <select
+          value={preset}
+          onChange={(e) => onPresetChange(e.target.value)}
+          className="bg-gray-800 text-white rounded p-2"
+        >
+          {presets.map((p) => (
+            <option key={p.value} value={p.value}>{p.label}</option>
+          ))}
+        </select>
+      </div>
+      {onTeamChange && (
+        <div>
+          <label className="block text-sm text-gray-300">Equipo</label>
+          <input
+            type="text"
+            value={team}
+            onChange={(e) => onTeamChange(e.target.value)}
+            className="bg-gray-800 text-white rounded p-2"
+            placeholder="Equipo"
+          />
+        </div>
+      )}
+      {onSearchChange && (
+        <div className="flex-1">
+          <label className="block text-sm text-gray-300">Empleado</label>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="bg-gray-800 text-white rounded p-2 w-full"
+            placeholder="Buscar..."
+          />
+        </div>
+      )}
+      {preset === 'custom' && onRangeChange && (
+        <div className="flex gap-2">
+          <div>
+            <label className="block text-sm text-gray-300">Desde</label>
+            <input
+              type="date"
+              value={localFrom}
+              onChange={(e) => handleRangeChange(e.target.value, localTo)}
+              className="bg-gray-800 text-white rounded p-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-300">Hasta</label>
+            <input
+              type="date"
+              value={localTo}
+              onChange={(e) => handleRangeChange(localFrom, e.target.value)}
+              className="bg-gray-800 text-white rounded p-2"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/attendance/KpiCards.tsx
+++ b/components/attendance/KpiCards.tsx
@@ -1,0 +1,26 @@
+interface KpiCardsProps {
+  presentes: number
+  ausentes: number
+  temprano: number
+  tarde: number
+}
+
+export default function KpiCards({ presentes, ausentes, temprano, tarde }: KpiCardsProps) {
+  const items = [
+    { label: 'Presentes', value: presentes, color: 'text-emerald-400' },
+    { label: 'Ausentes', value: ausentes, color: 'text-red-400' },
+    { label: 'Temprano', value: temprano, color: 'text-blue-400' },
+    { label: 'Tarde', value: tarde, color: 'text-yellow-400' }
+  ]
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {items.map((k) => (
+        <div key={k.label} className="bg-gray-800 rounded p-4 text-center">
+          <div className={`text-2xl font-bold ${k.color}`}>{k.value}</div>
+          <div className="text-gray-300 text-sm">{k.label}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/attendance/PunctualityTable.tsx
+++ b/components/attendance/PunctualityTable.tsx
@@ -1,0 +1,46 @@
+interface Row {
+  id: string
+  name: string
+  team?: string
+  delta_min: number
+  check_in_time: string
+}
+
+interface PunctualityTableProps {
+  data: Row[]
+  type: 'early' | 'late'
+  onSelect?: (id: string, name: string) => void
+}
+
+export default function PunctualityTable({ data, type, onSelect }: PunctualityTableProps) {
+  return (
+    <div className="bg-gray-800 rounded p-4">
+      <h3 className="text-white font-semibold mb-2">{type === 'early' ? 'Tempranos' : 'Tarde'} hoy</h3>
+      <table className="w-full text-sm text-left">
+        <thead className="text-gray-300">
+          <tr>
+            <th className="py-1">Empleado</th>
+            <th className="py-1">Equipo</th>
+            <th className="py-1">Entrada</th>
+            <th className="py-1">Δ min</th>
+          </tr>
+        </thead>
+        <tbody className="text-gray-100">
+          {data.map((row) => (
+            <tr key={row.id} className="border-t border-gray-700 hover:bg-gray-700/50 cursor-pointer" onClick={() => onSelect && onSelect(row.id, row.name)}>
+              <td className="py-1">{row.name}</td>
+              <td className="py-1">{row.team || '-'}</td>
+              <td className="py-1">{new Date(row.check_in_time).toLocaleTimeString('es-HN',{hour:'2-digit',minute:'2-digit'})}</td>
+              <td className="py-1">{row.delta_min}</td>
+            </tr>
+          ))}
+          {data.length === 0 && (
+            <tr>
+              <td colSpan={4} className="text-center py-4 text-gray-400">Sin datos</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/docs/ATTENDANCE_DASHBOARD.md
+++ b/docs/ATTENDANCE_DASHBOARD.md
@@ -1,0 +1,50 @@
+# Attendance Dashboard
+
+Esta sección describe los presets de fecha y ejemplos de consultas utilizados por el módulo de asistencia.
+
+## Presets de Fecha
+
+- **Hoy**: rango del día actual.
+- **Semana**: desde el lunes hasta el domingo de la semana actual.
+- **Quincena**: 1-15 o 16-fin de mes según la fecha actual.
+- **Mes**: todo el mes en curso.
+- **Año**: desde el 1 de enero al 31 de diciembre.
+- **Custom**: rango definido manualmente.
+
+## Ejemplos de Consultas
+
+Presentes vs ausentes en un rango:
+
+```sql
+with base as (
+  select e.id as employee_id,
+         exists(
+           select 1 from attendance_events ev
+           where ev.employee_id = e.id
+             and ev.event_type = 'check_in'
+             and ev.ts_local >= $1 and ev.ts_local < $2
+         ) as has_checkin
+  from employees e
+)
+select
+  count(*) filter (where has_checkin) as presentes,
+  count(*) filter (where not has_checkin) as ausentes
+from base;
+```
+
+Llegadas temprano o tarde hoy:
+
+```sql
+select e.id, e.name, e.team,
+       date_trunc('minute', ev.ts_local) as check_in_time,
+       extract(epoch from (ev.ts_local::time - e.shift_start)) / 60 as delta_min
+from employees e
+join lateral (
+  select ev.* from attendance_events ev
+  where ev.employee_id = e.id
+    and ev.event_type = 'check_in'
+    and ev.ts_local::date = (now() at time zone 'America/Tegucigalpa')::date
+  order by ev.ts_local asc
+  limit 1
+) ev on true;
+```

--- a/lib/attendance.js
+++ b/lib/attendance.js
@@ -1,0 +1,36 @@
+const { DateTime } = require('luxon')
+
+function getDateRange(preset, today = DateTime.now().setZone('America/Tegucigalpa')) {
+  switch (preset) {
+    case 'today': {
+      const from = today.startOf('day')
+      const to = from.plus({ days: 1 })
+      return { from: from.toISO(), to: to.toISO() }
+    }
+    case 'week': {
+      const from = today.startOf('week')
+      const to = from.plus({ weeks: 1 })
+      return { from: from.toISO(), to: to.toISO() }
+    }
+    case 'fortnight': {
+      const day = today.day
+      const from = day <= 15 ? today.startOf('month') : today.startOf('month').plus({ days: 15 })
+      const to = day <= 15 ? from.plus({ days: 15 }) : from.endOf('month').plus({ days: 1 })
+      return { from: from.toISO(), to: to.toISO() }
+    }
+    case 'month': {
+      const from = today.startOf('month')
+      const to = from.plus({ months: 1 })
+      return { from: from.toISO(), to: to.toISO() }
+    }
+    case 'year': {
+      const from = today.startOf('year')
+      const to = from.plus({ years: 1 })
+      return { from: from.toISO(), to: to.toISO() }
+    }
+    default:
+      return { from: today.toISO(), to: today.toISO() }
+  }
+}
+
+module.exports = { getDateRange }

--- a/lib/attendance.ts
+++ b/lib/attendance.ts
@@ -1,0 +1,39 @@
+import { DateTime } from 'luxon'
+
+export interface DateRange {
+  from: string
+  to: string
+}
+
+export function getDateRange(preset: string, today: DateTime = DateTime.now().setZone('America/Tegucigalpa')): DateRange {
+  switch (preset) {
+    case 'today': {
+      const from = today.startOf('day')
+      const to = from.plus({ days: 1 })
+      return { from: from.toISO(), to: to.toISO() }
+    }
+    case 'week': {
+      const from = today.startOf('week')
+      const to = from.plus({ weeks: 1 })
+      return { from: from.toISO(), to: to.toISO() }
+    }
+    case 'fortnight': {
+      const day = today.day
+      const from = day <= 15 ? today.startOf('month') : today.startOf('month').plus({ days: 15 })
+      const to = day <= 15 ? from.plus({ days: 15 }) : from.endOf('month').plus({ days: 1 })
+      return { from: from.toISO(), to: to.toISO() }
+    }
+    case 'month': {
+      const from = today.startOf('month')
+      const to = from.plus({ months: 1 })
+      return { from: from.toISO(), to: to.toISO() }
+    }
+    case 'year': {
+      const from = today.startOf('year')
+      const to = from.plus({ years: 1 })
+      return { from: from.toISO(), to: to.toISO() }
+    }
+    default:
+      return { from: today.toISO(), to: today.toISO() }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "node --test tests/*.js",
     "audit": "./scripts/run-complete-audit.sh",
     "audit:system": "node scripts/audit-system.js",
     "audit:supabase": "node scripts/audit-supabase.js",

--- a/pages/api/attendance/aggregate.ts
+++ b/pages/api/attendance/aggregate.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { createAdminClient } from '../../../lib/supabase/server'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { grain = 'day', from, to } = req.query
+  const supabase = createAdminClient()
+  const { data, error } = await supabase.rpc('attendance_aggregate', {
+    grain: grain as string,
+    from: from as string,
+    to: to as string
+  })
+  if (error) {
+    console.error('attendance_aggregate error', error)
+    return res.status(500).json({ error: error.message })
+  }
+  res.status(200).json(data)
+}

--- a/pages/api/attendance/employee/[id].ts
+++ b/pages/api/attendance/employee/[id].ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { createAdminClient } from '../../../../lib/supabase/server'
+import { getDateRange } from '../../../../lib/attendance'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query
+  const { preset = 'week', from, to } = req.query
+  const range = typeof from === 'string' && typeof to === 'string'
+    ? { from, to }
+    : getDateRange(preset as string)
+
+  const supabase = createAdminClient()
+  const { data, error } = await supabase.rpc('attendance_employee_timeline', {
+    employee_id: id as string,
+    from: range.from,
+    to: range.to
+  })
+  if (error) {
+    console.error('attendance_employee_timeline error', error)
+    return res.status(500).json({ error: error.message })
+  }
+  res.status(200).json(data)
+}

--- a/pages/api/attendance/export.ts
+++ b/pages/api/attendance/export.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { createAdminClient } from '../../../lib/supabase/server'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { format = 'csv', from, to } = req.query
+  const supabase = createAdminClient()
+  const { data, error } = await supabase.rpc('attendance_export', {
+    from: from as string,
+    to: to as string
+  })
+  if (error) {
+    console.error('attendance_export error', error)
+    return res.status(500).json({ error: error.message })
+  }
+  if (format === 'csv') {
+    const headers = Object.keys(data[0] || {})
+    const csv = [headers.join(','), ...(data as any[]).map(row => headers.map(h => row[h]).join(','))].join('\n')
+    res.setHeader('Content-Type', 'text/csv')
+    res.setHeader('Content-Disposition', 'attachment; filename="attendance.csv"')
+    return res.status(200).send(csv)
+  }
+  res.status(200).json(data)
+}

--- a/pages/api/attendance/kpis.ts
+++ b/pages/api/attendance/kpis.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { createAdminClient } from '../../../lib/supabase/server'
+import { getDateRange } from '../../../lib/attendance'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { preset = 'today', from, to, team } = req.query
+  const range = typeof from === 'string' && typeof to === 'string'
+    ? { from, to }
+    : getDateRange(preset as string)
+
+  const supabase = createAdminClient()
+  const { data, error } = await supabase.rpc('attendance_kpis', {
+    from: range.from,
+    to: range.to,
+    team: team as string | null
+  })
+
+  if (error) {
+    console.error('attendance_kpis error', error)
+    return res.status(500).json({ error: error.message })
+  }
+
+  res.status(200).json(data)
+}

--- a/pages/api/attendance/lists.ts
+++ b/pages/api/attendance/lists.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { createAdminClient } from '../../../lib/supabase/server'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { scope = 'today', type = 'absent' } = req.query
+  const supabase = createAdminClient()
+  const { data, error } = await supabase.rpc('attendance_lists', {
+    scope: scope as string,
+    type: type as string
+  })
+  if (error) {
+    console.error('attendance_lists error', error)
+    return res.status(500).json({ error: error.message })
+  }
+  res.status(200).json(data)
+}

--- a/pages/attendance/dashboard.tsx
+++ b/pages/attendance/dashboard.tsx
@@ -1,431 +1,79 @@
-import { useState, useEffect } from 'react'
-import { supabase } from '../../lib/supabase'
+import { useEffect, useState } from 'react'
 import ProtectedRoute from '../../components/ProtectedRoute'
 import DashboardLayout from '../../components/DashboardLayout'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card'
-import { Button } from '../../components/ui/button'
-import { Badge } from '../../components/ui/badge'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../components/ui/select'
+import FiltersBar from '../../components/attendance/FiltersBar'
+import KpiCards from '../../components/attendance/KpiCards'
+import AbsenceTable from '../../components/attendance/AbsenceTable'
+import PunctualityTable from '../../components/attendance/PunctualityTable'
+import EmployeeDrawer from '../../components/attendance/EmployeeDrawer'
+import ExportButton from '../../components/attendance/ExportButton'
+import { getDateRange } from '../../lib/attendance'
+import { createAdminClient } from '../../lib/supabase/server'
 
-interface AttendanceStats {
-  totalEmployees: number
-  presentToday: number
-  absentToday: number
-  lateToday: number
-  onTimeToday: number
-  employeesWithApprovedLeave: number
-  dailyCost: number
-  dailyStats: Array<{
-    date: string
-    attendanceCount: number
-    attendanceRate: number
-  }>
-  departmentStats: Record<string, { present: number; total: number }>
-  todayAttendance: Array<{
-    id: string
-    employee_id: string
-    employee_name: string
-    employee_code: string
-    check_in: string
-    check_out: string
-    late_minutes: number
-    status: string
-    justification: string
-  }>
+interface DashboardProps {
+  initialKpis: any
+  initialLists: { absent: any[]; early: any[]; late: any[] }
 }
 
-export default function AttendanceDashboard2() {
-  const [stats, setStats] = useState<AttendanceStats | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [exportLoading, setExportLoading] = useState(false)
-  const [selectedRange, setSelectedRange] = useState('daily')
-  const [selectedFormat, setSelectedFormat] = useState('pdf')
+export default function AttendanceDashboard({ initialKpis, initialLists }: DashboardProps) {
+  const [preset, setPreset] = useState('today')
+  const [kpis, setKpis] = useState(initialKpis)
+  const [absent, setAbsent] = useState(initialLists.absent)
+  const [early, setEarly] = useState(initialLists.early)
+  const [late, setLate] = useState(initialLists.late)
+  const [drawer, setDrawer] = useState<{open:boolean; name:string; events:any[]}>({open:false,name:'',events:[]})
 
-  const fetchStats = async () => {
-    try {
-      const response = await fetch('/api/attendance/dashboard-stats')
-      if (response.ok) {
-        const data = await response.json()
-        setStats(data)
-      } else {
-        console.error('Error fetching stats:', response.statusText)
-      }
-    } catch (error) {
-      console.error('Error:', error)
-    } finally {
-      setLoading(false)
-    }
+  const loadData = async (p: string) => {
+    const kpiRes = await fetch(`/api/attendance/kpis?preset=${p}`)
+    setKpis(await kpiRes.json())
+    const absentRes = await fetch(`/api/attendance/lists?scope=today&type=absent`)
+    setAbsent(await absentRes.json())
+    const earlyRes = await fetch(`/api/attendance/lists?scope=today&type=early`)
+    setEarly(await earlyRes.json())
+    const lateRes = await fetch(`/api/attendance/lists?scope=today&type=late`)
+    setLate(await lateRes.json())
   }
 
-  useEffect(() => {
-    fetchStats()
-    
-    // Actualizar cada 5 minutos
-    const interval = setInterval(fetchStats, 5 * 60 * 1000)
-    return () => clearInterval(interval)
-  }, [])
-
-  const exportReport = async () => {
-    setExportLoading(true)
-    try {
-      const response = await fetch('/api/attendance/export-report', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          range: selectedRange,
-          format: selectedFormat
-        })
-      })
-
-      if (response.ok) {
-        const blob = await response.blob()
-        const url = window.URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = `reporte_asistencia_${selectedRange}_${new Date().toISOString().split('T')[0]}.${selectedFormat}`
-        document.body.appendChild(a)
-        a.click()
-        window.URL.revokeObjectURL(url)
-        document.body.removeChild(a)
-      } else {
-        console.error('Error exporting report:', response.statusText)
-      }
-    } catch (error) {
-      console.error('Error:', error)
-    } finally {
-      setExportLoading(false)
-    }
+  const handlePresetChange = (p: string) => {
+    setPreset(p)
+    loadData(p)
   }
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('es-HN', {
-      style: 'currency',
-      currency: 'HNL'
-    }).format(amount)
+  const handleExport = async (format: string) => {
+    await fetch(`/api/attendance/export?format=${format}&preset=${preset}`)
   }
 
-  const formatTime = (timestamp: string | null) => {
-    if (!timestamp) return 'N/A'
-    return new Date(timestamp).toLocaleTimeString('es-HN', {
-      hour: '2-digit',
-      minute: '2-digit'
-    })
-  }
-
-  const getStatusBadge = (record: any) => {
-    if (!record.check_in) return <Badge variant="destructive" className="bg-red-500/20 text-red-400">Ausente</Badge>
-    if (record.late_minutes > 0) return <Badge variant="secondary" className="bg-yellow-500/20 text-yellow-400">Tardanza ({record.late_minutes} min)</Badge>
-    if (record.check_out) return <Badge variant="default" className="bg-brand-500/20 text-brand-400">Completo</Badge>
-    return <Badge variant="outline" className="bg-emerald-500/20 text-emerald-400 border-emerald-500/30">Presente</Badge>
-  }
-
-  if (loading) {
-    return (
-      <ProtectedRoute>
-        <DashboardLayout>
-          <div className="flex items-center justify-center min-h-screen">
-            <div className="text-center">
-              <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-brand-400 mx-auto"></div>
-              <p className="mt-4 text-gray-300">Cargando dashboard de asistencia...</p>
-            </div>
-          </div>
-        </DashboardLayout>
-      </ProtectedRoute>
-    )
-  }
-
-  if (!stats) {
-    return (
-      <ProtectedRoute>
-        <DashboardLayout>
-          <div className="text-center py-8">
-            <p className="text-red-400">Error cargando estadísticas</p>
-          </div>
-        </DashboardLayout>
-      </ProtectedRoute>
-    )
+  const handleEmployeeClick = async (id: string, name: string) => {
+    const res = await fetch(`/api/attendance/employee/${id}?preset=${preset}`)
+    const events = await res.json()
+    setDrawer({open:true, name, events})
   }
 
   return (
     <ProtectedRoute>
       <DashboardLayout>
         <div className="space-y-6">
-          {/* Header */}
-          <div className="flex justify-between items-center">
-            <div>
-              <h1 className="text-3xl font-bold text-white">Dashboard de Asistencia 2.0</h1>
-              <p className="text-gray-300">Vista en tiempo real de la asistencia del día</p>
-            </div>
-            <div className="flex gap-2">
-              <Button onClick={() => window.location.href = '/attendance/register'} className="bg-brand-600 hover:bg-brand-700">
-                Ir a Registro
-              </Button>
-            </div>
+          <FiltersBar preset={preset} onPresetChange={handlePresetChange} />
+          <KpiCards presentes={kpis.presentes||0} ausentes={kpis.ausentes||0} temprano={kpis.tempranos||0} tarde={kpis.tardes||0} />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <AbsenceTable data={absent} title="Ausentes hoy" onSelect={handleEmployeeClick} />
+            <PunctualityTable data={early} type='early' onSelect={handleEmployeeClick} />
+            <PunctualityTable data={late} type='late' onSelect={handleEmployeeClick} />
           </div>
-
-          {/* Estadísticas Principales */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
-            {/* Tasa de Asistencia - Métrica Principal */}
-            <Card variant="glass" className="lg:col-span-2">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-lg font-semibold flex items-center gap-2 text-white">
-                  📊 Tasa de Asistencia Diaria
-                </CardTitle>
-                <CardDescription className="text-gray-300">Métrica principal del día</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  <div className="text-center">
-                    <div className={`text-4xl font-bold ${
-                      stats.totalEmployees > 0 && (stats.presentToday / stats.totalEmployees) * 100 >= 90 ? 'text-emerald-400' :
-                      stats.totalEmployees > 0 && (stats.presentToday / stats.totalEmployees) * 100 >= 80 ? 'text-yellow-400' :
-                      'text-red-400'
-                    }`}>
-                      {stats.totalEmployees > 0 ? ((stats.presentToday / stats.totalEmployees) * 100).toFixed(1) : 0}%
-                    </div>
-                    <div className={`text-sm font-medium ${
-                      stats.totalEmployees > 0 && (stats.presentToday / stats.totalEmployees) * 100 >= 90 ? 'text-emerald-400' :
-                      stats.totalEmployees > 0 && (stats.presentToday / stats.totalEmployees) * 100 >= 80 ? 'text-yellow-400' :
-                      'text-red-400'
-                    }`}>
-                      {stats.totalEmployees > 0 && (stats.presentToday / stats.totalEmployees) * 100 >= 90 ? '🟢 Excelente' :
-                       stats.totalEmployees > 0 && (stats.presentToday / stats.totalEmployees) * 100 >= 80 ? '🟡 Bueno' :
-                       '🔴 Requiere Atención'}
-                    </div>
-                  </div>
-                  <div className="relative">
-                    <div className="w-full bg-white/20 rounded-full h-4">
-                      <div 
-                        className={`h-4 rounded-full transition-all duration-700 ${
-                          stats.totalEmployees > 0 && (stats.presentToday / stats.totalEmployees) * 100 >= 90 ? 'bg-gradient-to-r from-emerald-400 to-emerald-600' :
-                          stats.totalEmployees > 0 && (stats.presentToday / stats.totalEmployees) * 100 >= 80 ? 'bg-gradient-to-r from-yellow-400 to-yellow-600' :
-                          'bg-gradient-to-r from-red-400 to-red-600'
-                        }`}
-                        style={{ width: `${stats.totalEmployees > 0 ? Math.min((stats.presentToday / stats.totalEmployees) * 100, 100) : 0}%` }}
-                      ></div>
-                    </div>
-                  </div>
-                  <div className="grid grid-cols-2 gap-4 text-sm">
-                    <div className="text-center">
-                      <div className="font-bold text-emerald-400">{stats.presentToday}</div>
-                      <div className="text-gray-300">Presentes</div>
-                    </div>
-                    <div className="text-center">
-                      <div className="font-bold text-red-400">{stats.absentToday}</div>
-                      <div className="text-gray-300">Ausentes</div>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card variant="glass">
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium text-white">Total Empleados</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold text-white">{stats.totalEmployees}</div>
-                <p className="text-xs text-gray-300">
-                  Empleados activos en el sistema
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card variant="glass">
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium text-white">Tardanzas</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold text-orange-400">{stats.lateToday}</div>
-                <p className="text-xs text-gray-300">
-                  {stats.presentToday > 0 ? ((stats.lateToday / stats.presentToday) * 100).toFixed(1) : 0}% de los presentes
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card variant="glass">
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium text-white">A Tiempo</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold text-brand-400">{stats.onTimeToday}</div>
-                <p className="text-xs text-gray-300">
-                  Llegadas puntuales del día
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Estadísticas Secundarias */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <Card variant="glass">
-              <CardHeader>
-                <CardTitle className="text-white">Ausentes</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-3xl font-bold text-red-400">{stats.absentToday}</div>
-                <p className="text-sm text-gray-300">
-                  Sin registro de entrada
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card variant="glass">
-              <CardHeader>
-                <CardTitle className="text-white">A Tiempo</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-3xl font-bold text-emerald-400">{stats.onTimeToday}</div>
-                <p className="text-sm text-gray-300">
-                  Sin tardanzas
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card variant="glass">
-              <CardHeader>
-                <CardTitle className="text-white">Con Permisos</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-3xl font-bold text-purple-400">{stats.employeesWithApprovedLeave}</div>
-                <p className="text-sm text-gray-300">
-                  Permisos aprobados
-                </p>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Gráfico de Últimos 7 Días */}
-          <Card variant="glass">
-            <CardHeader>
-              <CardTitle className="text-white">Asistencia Últimos 7 Días</CardTitle>
-              <CardDescription className="text-gray-300">
-                Tasa de asistencia diaria
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-end space-x-2 h-32">
-                {stats.dailyStats.map((day, index) => (
-                  <div key={day.date} className="flex-1 flex flex-col items-center">
-                    <div 
-                      className="w-full bg-brand-500 rounded-t"
-                      style={{ 
-                        height: `${(day.attendanceRate / 100) * 100}%`,
-                        minHeight: '4px'
-                      }}
-                    ></div>
-                    <div className="text-xs text-gray-300 mt-1">
-                      {new Date(day.date).toLocaleDateString('es-HN', { day: '2-digit', month: '2-digit' })}
-                    </div>
-                    <div className="text-xs font-medium text-white">
-                      {day.attendanceRate}%
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Exportar Reportes */}
-          <Card variant="glass">
-            <CardHeader>
-              <CardTitle className="text-white">Exportar Reportes</CardTitle>
-              <CardDescription className="text-gray-300">
-                Genera reportes en PDF o CSV
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="flex gap-4 items-end">
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">
-                    Rango
-                  </label>
-                  <Select value={selectedRange} onValueChange={setSelectedRange}>
-                    <SelectTrigger className="w-32 bg-white/10 border-white/20 text-white">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="daily">Diario</SelectItem>
-                      <SelectItem value="weekly">Semanal</SelectItem>
-                      <SelectItem value="biweekly">Quincenal</SelectItem>
-                      <SelectItem value="monthly">Mensual</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">
-                    Formato
-                  </label>
-                  <Select value={selectedFormat} onValueChange={setSelectedFormat}>
-                    <SelectTrigger className="w-24 bg-white/10 border-white/20 text-white">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="pdf">PDF</SelectItem>
-                      <SelectItem value="csv">CSV</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <Button 
-                  onClick={exportReport} 
-                  disabled={exportLoading}
-                  className="bg-emerald-600 hover:bg-emerald-700"
-                >
-                  {exportLoading ? 'Generando...' : 'Exportar'}
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Tabla de Asistencia del Día */}
-          <Card variant="glass">
-            <CardHeader>
-              <CardTitle className="text-white">Registros de Asistencia - {new Date().toLocaleDateString('es-HN')}</CardTitle>
-              <CardDescription className="text-gray-300">
-                {stats.todayAttendance.length} registros encontrados
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="overflow-x-auto">
-                <table className="w-full table-auto">
-                  <thead>
-                    <tr className="border-b border-white/10">
-                      <th className="text-left py-3 px-4 text-gray-300">Empleado</th>
-                      <th className="text-left py-3 px-4 text-gray-300">Código</th>
-                      <th className="text-left py-3 px-4 text-gray-300">Entrada</th>
-                      <th className="text-left py-3 px-4 text-gray-300">Salida</th>
-                      <th className="text-left py-3 px-4 text-gray-300">Estado</th>
-                      <th className="text-left py-3 px-4 text-gray-300">Justificación</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {stats.todayAttendance.map((record) => (
-                      <tr key={record.id} className="border-b border-white/10 hover:bg-white/5">
-                        <td className="py-3 px-4 text-white">{record.employee_name}</td>
-                        <td className="py-3 px-4 text-gray-300">{record.employee_code}</td>
-                        <td className="py-3 px-4 text-gray-300">{formatTime(record.check_in)}</td>
-                        <td className="py-3 px-4 text-gray-300">{formatTime(record.check_out)}</td>
-                        <td className="py-3 px-4">{getStatusBadge(record)}</td>
-                        <td className="py-3 px-4">
-                          {record.justification ? (
-                            <span className="text-sm text-gray-300">{record.justification}</span>
-                          ) : (
-                            <span className="text-sm text-gray-400">Sin justificación</span>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </CardContent>
-          </Card>
+          <ExportButton onExport={handleExport} />
         </div>
+        <EmployeeDrawer open={drawer.open} onClose={() => setDrawer({open:false,name:'',events:[]})} name={drawer.name} events={drawer.events} />
       </DashboardLayout>
     </ProtectedRoute>
   )
-} 
+}
+
+export async function getServerSideProps() {
+  const supabase = createAdminClient()
+  const range = getDateRange('today')
+  const { data: kpis } = await supabase.rpc('attendance_kpis', { from: range.from, to: range.to })
+  const { data: absent } = await supabase.rpc('attendance_lists', { scope: 'today', type: 'absent' })
+  const { data: early } = await supabase.rpc('attendance_lists', { scope: 'today', type: 'early' })
+  const { data: late } = await supabase.rpc('attendance_lists', { scope: 'today', type: 'late' })
+  return { props: { initialKpis: kpis, initialLists: { absent, early, late } } }
+}

--- a/supabase/migrations/20250802000003_add_attendance_indices.sql
+++ b/supabase/migrations/20250802000003_add_attendance_indices.sql
@@ -1,0 +1,4 @@
+-- Adds indices for attendance queries
+create index if not exists idx_att_ev_employee_ts on attendance_events(employee_id, ts_local);
+create index if not exists idx_att_ev_type_ts on attendance_events(event_type, ts_local);
+create index if not exists idx_emp_team on employees(team);

--- a/tests/dateRange.test.js
+++ b/tests/dateRange.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test')
+const assert = require('node:assert')
+const { DateTime } = require('luxon')
+const { getDateRange } = require('../lib/attendance.js')
+
+test('fortnight first half', () => {
+  const today = DateTime.fromISO('2024-05-10', { zone: 'America/Tegucigalpa' })
+  const { from, to } = getDateRange('fortnight', today)
+  assert.equal(from.slice(0,10), '2024-05-01')
+  assert.equal(to.slice(0,10), '2024-05-16')
+})
+
+test('fortnight second half', () => {
+  const today = DateTime.fromISO('2024-05-20', { zone: 'America/Tegucigalpa' })
+  const { from, to } = getDateRange('fortnight', today)
+  assert.equal(from.slice(0,10), '2024-05-16')
+  assert.equal(to.slice(0,10), '2024-06-01')
+})


### PR DESCRIPTION
## Summary
- implement date range utility with Honduran timezone presets
- rebuild attendance dashboard with KPI cards, filters and drill downs
- add server-side RPC API endpoints and indices for faster attendance queries

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e159dbd4c8329ad2bfc8095923863