### PR TITLE
feat: add i18n support with locale switcher

### DIFF
--- a/components/AWSCertificationsSection.tsx
+++ b/components/AWSCertificationsSection.tsx
@@ -1,47 +1,24 @@
 import Image from 'next/image'
-import { CheckBadgeIcon, StarIcon } from '@heroicons/react/24/solid'
+import { CheckBadgeIcon } from '@heroicons/react/24/solid'
+import { useTranslation } from 'next-i18next'
 
 export default function AWSCertificationsSection() {
-  const certifications = [
-    {
-      name: 'AWS Solutions Architect',
-      level: 'ASSOCIATE',
-      icon: '/image-aws-solutions-architect.png',
-      badgeColor: 'bg-blue-500/10 text-blue-400 border-blue-500/20'
-    },
-    {
-      name: 'AWS Developer',
-      level: 'ASSOCIATE',
-      icon: '/image-aws-developer.png',
-      badgeColor: 'bg-blue-500/10 text-blue-400 border-blue-500/20'
-    },
-    {
-      name: 'AWS Cloud Practitioner',
-      level: 'FOUNDATIONAL',
-      icon: '/image-aws-cloud-practitioner.png',
-      badgeColor: 'bg-gray-400/10 text-gray-300 border-gray-400/20'
-    }
-  ]
+  const { t } = useTranslation('landing')
+  const certifications = t('aws.certifications', { returnObjects: true }) as any[]
 
   return (
     <section className="py-16 bg-white/5">
       <div className="max-w-6xl mx-auto px-4">
         {/* Header */}
         <div className="text-center mb-12">
-          <h2 className="text-3xl font-bold text-white mb-6">
-            Desarrollado por ingenieros certificados en AWS
-          </h2>
-          
+          <h2 className="text-3xl font-bold text-white mb-6">{t('aws.title')}</h2>
+
           <p className="text-brand-200/90 max-w-4xl mx-auto mb-8 text-lg">
-            Hecho con la misma tecnología que usan Netflix y Airbnb, ahora para tu MIPYMES en Honduras
+            {t('aws.tagline1')}
             <br />
-            <span className="text-brand-400 font-medium">
-              Optimizado para que tu empresa en Honduras tenga la seguridad y escalabilidad de un gigante, sin pagar como uno.
-            </span>
+            <span className="text-brand-400 font-medium">{t('aws.tagline2')}</span>
             <br />
-            <span className="text-white font-semibold">
-              Tecnología global. Precio local.
-            </span>
+            <span className="text-white font-semibold">{t('aws.tagline3')}</span>
           </p>
 
           {/* AWS Certification Badges - EXACTAMENTE como en la barra superior */}
@@ -63,9 +40,7 @@ export default function AWSCertificationsSection() {
                 </div>
                 
                 {/* Texto de la certificación */}
-                <div className="text-sm font-medium text-white">
-                  {cert.name}
-                </div>
+                <div className="text-sm font-medium text-white">{cert.name}</div>
               </div>
             ))}
           </div>
@@ -75,9 +50,7 @@ export default function AWSCertificationsSection() {
         <div className="text-center">
           <div className="inline-flex items-center gap-3 bg-green-500/10 text-green-400 px-4 py-2 rounded-full border border-green-500/20 hover:bg-green-500/20 transition-all duration-300 hover:-translate-y-0.5">
             <CheckBadgeIcon className="h-5 w-5" />
-            <span className="font-medium">
-              Garantía de calidad y seguridad certificada por AWS
-            </span>
+            <span className="font-medium">{t('aws.guarantee')}</span>
           </div>
         </div>
       </div>

--- a/components/CountdownTimer.tsx
+++ b/components/CountdownTimer.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from 'react'
 import { nowInHonduras } from '../lib/timezone'
+import { useTranslation } from 'next-i18next'
 
 export default function CountdownTimer() {
   // Countdown to next quincena (15 o último día del mes)
@@ -38,30 +39,32 @@ export default function CountdownTimer() {
     };
   }, [now]);
 
+  const { t } = useTranslation(['common', 'landing'])
+
   return (
     <div className="text-center mb-12">
       <div className="bg-gradient-to-r from-blue-500/20 to-orange-500/20 border border-black-400/30 rounded-2xl p-6 backdrop-blur-sm shadow-xl max-w-4xl mx-auto">
         <div className="text-center mb-4">
-          <h3 className="text-lg font-semibold text-red-100 mb-2">TU PROXIMA FECHA DE PAGO ES EN</h3>
+          <h3 className="text-lg font-semibold text-red-100 mb-2">{t('countdown.title')}</h3>
           <div className="flex items-center justify-center gap-3 text-3xl font-bold text-white">
             <div className="bg-white/20 rounded-xl px-4 py-2 min-w-[80px]">
               <span className="block text-4xl">{daysLeft}</span>
-              <span className="text-sm text-red-100">DÍAS</span>
+              <span className="text-sm text-red-100">{t('countdown.labels.days')}</span>
             </div>
             <span className="text-red-300">:</span>
             <div className="bg-white/20 rounded-xl px-4 py-2 min-w-[80px]">
               <span className="block text-4xl">{hoursLeft.toString().padStart(2, '0')}</span>
-              <span className="text-sm text-red-100">HORAS</span>
+              <span className="text-sm text-red-100">{t('countdown.labels.hours')}</span>
             </div>
             <span className="text-red-300">:</span>
             <div className="bg-white/20 rounded-xl px-4 py-2 min-w-[80px]">
               <span className="block text-4xl">{minutesLeft.toString().padStart(2, '0')}</span>
-              <span className="text-sm text-red-100">MIN</span>
+              <span className="text-sm text-red-100">{t('countdown.labels.minutes')}</span>
             </div>
             <span className="text-red-300">:</span>
             <div className="bg-white/20 rounded-xl px-4 py-2 min-w-[80px]">
               <span className="block text-4xl">{secondsLeft.toString().padStart(2, '0')}</span>
-              <span className="text-sm text-red-100">SEG</span>
+              <span className="text-sm text-red-100">{t('countdown.labels.seconds')}</span>
             </div>
           </div>
         </div>
@@ -71,21 +74,21 @@ export default function CountdownTimer() {
             <div className="flex flex-col sm:flex-row gap-3 max-w-md mx-auto">
               <input
                 type="email"
-                placeholder="Tu email"
+                placeholder={t('common:cta.emailPlaceholder')}
                 className="flex-1 px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-red-100/70 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:border-transparent"
               />
               <button
-                onClick={() => window.location.href = '/activar'}
+                onClick={() => (window.location.href = '/activar')}
                 className="inline-flex items-center justify-center rounded-xl px-6 py-3 text-base font-semibold shadow-lg bg-sky-600 text-white hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400 transition-all duration-300 hover:-translate-y-0.5 whitespace-nowrap"
                 data-analytics="cta_countdown_click"
               >
-                Comenza HOY
+                {t('common:cta.startToday')}
               </button>
             </div>
             
             {/* Features text below CTA */}
             <div className="text-sm text-red-100/80">
-              <p>Usalo gratis 30 días. Empleados ilimitados.</p>
+              <p>{t('common:cta.trialNote')}</p>
             </div>
           </div>
         </div>

--- a/components/DemoFooter.tsx
+++ b/components/DemoFooter.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
+import { useTranslation } from 'next-i18next'
 
 const DemoFooter: React.FC = () => {
+  const { t } = useTranslation('landing')
   return (
     <footer className="bg-white border-t border-gray-200 mt-auto">
       <div className="max-w-6xl mx-auto px-4 py-8">
@@ -9,7 +11,7 @@ const DemoFooter: React.FC = () => {
           
           {/* Contact Info */}
           <div>
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">Contacto</h3>
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">{t('demoFooter.contact')}</h3>
             <div className="space-y-2">
               <div className="flex items-center text-gray-600">
                 <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -24,7 +26,7 @@ const DemoFooter: React.FC = () => {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
                 </svg>
                 <a href="https://wa.me/50494707007" target="_blank" rel="noopener noreferrer" className="hover:text-green-600">
-                  WhatsApp: 9470-7007
+                  {t('demoFooter.whatsapp')}
                 </a>
               </div>
             </div>
@@ -32,10 +34,8 @@ const DemoFooter: React.FC = () => {
 
           {/* Join Community */}
           <div>
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">Únete a la Comunidad</h3>
-            <p className="text-gray-600 text-sm mb-4">
-              Síguenos en nuestras redes sociales para conocer las últimas actualizaciones
-            </p>
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">{t('demoFooter.community.title')}</h3>
+            <p className="text-gray-600 text-sm mb-4">{t('demoFooter.community.text')}</p>
             <div className="flex space-x-4">
               {/* Facebook */}
               <a 
@@ -95,13 +95,11 @@ const DemoFooter: React.FC = () => {
 
           {/* About */}
           <div>
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">Humano SISU</h3>
-            <p className="text-gray-600 text-sm mb-4">
-              Tu RH 100% digital, legal y sin complicaciones. Hecho para PYMEs como la tuya.
-            </p>
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">{t('demoFooter.about.title')}</h3>
+            <p className="text-gray-600 text-sm mb-4">{t('demoFooter.about.desc')}</p>
             <div className="text-sm text-gray-500">
-              <p>© 2025 Humano SISU</p>
-              <p>Sistema de Recursos Humanos</p>
+              <p>{t('demoFooter.about.rights1')}</p>
+              <p>{t('demoFooter.about.rights2')}</p>
             </div>
           </div>
         </div>

--- a/components/LandingHero.tsx
+++ b/components/LandingHero.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import ImageCarousel from "./ImageCarousel";
+import React from 'react'
+import ImageCarousel from './ImageCarousel'
 import { nowInHonduras } from '../lib/timezone'
+import { useTranslation } from 'next-i18next'
 
 export default function LandingHero() {
   // Función simple para obtener la próxima quincena
@@ -18,6 +19,8 @@ export default function LandingHero() {
 
   const nextPayday = getNextPayday();
 
+  const { t } = useTranslation(['common', 'landing'])
+
   return (
     <div className="relative isolate overflow-hidden">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12 lg:py-20">
@@ -27,18 +30,19 @@ export default function LandingHero() {
             <div className="space-y-6 text-left">
 
               <h1 className="text-4xl sm:text-5xl font-extrabold leading-tight text-white">
-                ¿Siempre corriendo detras de Recursos Humanos?
-                <span className="block text-brand-300">Cambialos por robots y olvidate de las carreras para siempre.</span>
+                {t('hero.title')}
+                <span className="block text-brand-300">{t('hero.subtitle')}</span>
               </h1>
 
-              <p className="text-lg text-brand-200/90">
-                Generá planilla en 5 minutos, con IHSS, RAP e ISR listos y vouchers enviados por Mail/WhatsApp.
-              </p>
+              <p className="text-lg text-brand-200/90">{t('hero.description')}</p>
 
               <ul className="text-brand-200/80 space-y-2">
-                <li className="flex items-start gap-2"><span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500 mt-2" /> Cumplimiento STSS desde el día uno.</li>
-                <li className="flex items-start gap-2"><span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500 mt-2" /> De Excel caótico a PDF impecable en minutos.</li>
-                <li className="flex items-start gap-2"><span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500 mt-2" /> Ahorro de 6 horas por quincena.</li>
+                {(t('hero.bullets', { returnObjects: true }) as string[]).map((item) => (
+                  <li key={item} className="flex items-start gap-2">
+                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500 mt-2" />
+                    {item}
+                  </li>
+                ))}
               </ul>
 
               {/* Email CTA Section */}
@@ -46,21 +50,21 @@ export default function LandingHero() {
                 <div className="flex flex-col sm:flex-row gap-3 max-w-md">
                   <input
                     type="email"
-                    placeholder="Tu email"
+                    placeholder={t('common:cta.emailPlaceholder')}
                     className="flex-1 px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-brand-200/70 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:border-transparent"
                   />
                   <button
-                    onClick={() => window.location.href = '/activar'}
+                    onClick={() => (window.location.href = '/activar')}
                     className="inline-flex items-center justify-center rounded-xl px-6 py-3 text-lg font-semibold shadow-sm bg-sky-600 text-white hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400 transition-all duration-300 hover:-translate-y-1 whitespace-nowrap"
                     data-analytics="cta_hero_click"
                   >
-                    Comenza HOY
+                    {t('common:cta.startToday')}
                   </button>
                 </div>
-                
+
                 {/* Features text below CTA */}
                 <div className="text-sm text-brand-200/60">
-                  <p>Usalo gratis 30 días. Empleados ilimitados.</p>
+                  <p>{t('common:cta.trialNote')}</p>
                 </div>
               </div>
             </div>
@@ -74,7 +78,7 @@ export default function LandingHero() {
           {/* Frase de urgencia al final del componente */}
           <div className="text-center mt-12">
             <p className="text-xl font-semibold text-brand-200/90">
-              Próxima planilla: {nextPayday.toLocaleDateString()}. ¿Otra vez la vas a hacer desde cero?
+              {t('hero.nextPayroll', { date: nextPayday.toLocaleDateString() })}
             </p>
           </div>
         </div>

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,0 +1,18 @@
+import { useRouter } from 'next/router'
+
+export default function LanguageSwitcher() {
+  const router = useRouter()
+  const { locale, asPath } = router
+  const toggleLocale = locale === 'es' ? 'en' : 'es'
+
+  const switchLanguage = () => {
+    document.cookie = `LOCALE=${toggleLocale}; path=/; max-age=31536000`
+    router.push(asPath, asPath, { locale: toggleLocale })
+  }
+
+  return (
+    <button onClick={switchLanguage} className="text-sm text-brand-200 hover:text-white px-3 py-2">
+      {toggleLocale.toUpperCase()}
+    </button>
+  )
+}

--- a/components/ServicesSection.tsx
+++ b/components/ServicesSection.tsx
@@ -1,202 +1,162 @@
-import { ClockIcon, CurrencyDollarIcon, CheckCircleIcon, ArrowRightIcon } from '@heroicons/react/24/outline'
-import Link from 'next/link'
-import { Button } from './ui/button'
+import { ClockIcon, CurrencyDollarIcon, CheckCircleIcon } from '@heroicons/react/24/outline'
+import { useTranslation, Trans } from 'next-i18next'
 
 export default function ServicesSection() {
+  const { t } = useTranslation(['common', 'landing'])
+  const steps = t('services.steps', { returnObjects: true }) as any[]
+  const pulso = t('services.pulso', { returnObjects: true }) as any
+  const reports = t('services.reports', { returnObjects: true }) as any
+  const nomina = t('services.nomina', { returnObjects: true }) as any
+  const calculo = t('services.calculo', { returnObjects: true }) as any
+  const proofItems = t('services.proof.items', { returnObjects: true }) as string[]
+
   return (
     <section id="servicios" className="relative py-20 px-6 max-w-7xl mx-auto">
-      {/* sutil glow de fondo */}
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div className="mx-auto h-72 w-72 blur-3xl rounded-full opacity-20 bg-brand-600/40 translate-y-8" />
       </div>
 
-      {/* Cómo funciona section */}
       <div className="max-w-6xl mx-auto mb-20">
         <div className="text-center mb-8">
           <div className="inline-block bg-gray-800/50 text-gray-300 text-sm font-medium px-4 py-2 rounded-full mb-6">
-            CÓMO FUNCIONA
+            {t('services.howItWorks')}
           </div>
-          <h2 className="text-3xl font-bold text-white mb-8">
-            Reemplazá equipos internos costosos y consultores poco confiables por una tarifa mensual fija
-          </h2>
+          <h2 className="text-3xl font-bold text-white mb-8">{t('services.replace')}</h2>
         </div>
-        
+
         <div className="bg-gray-900/50 border border-green-500/30 rounded-2xl p-8 max-w-4xl mx-auto">
           <div className="space-y-8">
-            <div className="flex items-start gap-4">
-              <div className="flex-shrink-0 w-8 h-8 bg-green-500/20 rounded-full flex items-center justify-center">
-                <span className="text-green-400 font-bold text-lg">1</span>
+            {steps.map((step, i) => (
+              <div key={i} className="flex items-start gap-4">
+                <div className="flex-shrink-0 w-8 h-8 bg-green-500/20 rounded-full flex items-center justify-center">
+                  <span className="text-green-400 font-bold text-lg">{i + 1}</span>
+                </div>
+                <div>
+                  <h3 className="text-xl font-bold text-white mb-2">{step.title}</h3>
+                  <p className="text-gray-300">{step.desc}</p>
+                </div>
               </div>
-              <div>
-                <h3 className="text-xl font-bold text-white mb-2">No más contratar, gestionar o lidiar con personal de RH</h3>
-                <p className="text-gray-300">Automatizamos el 80% de las operaciones de Recursos Humanos por vos.</p>
-              </div>
-            </div>
-            
-            <div className="flex items-start gap-4">
-              <div className="flex-shrink-0 w-8 h-8 bg-green-500/20 rounded-full flex items-center justify-center">
-                <span className="text-green-400 font-bold text-lg">2</span>
-              </div>
-              <div>
-                <h3 className="text-xl font-bold text-white mb-2">Extraordinariamente simple de usar</h3>
-                <p className="text-gray-300">Agregá los parámetros específicos de tu caso de uso y nosotros nos encargamos del resto.</p>
-              </div>
-            </div>
-            
-            <div className="flex items-start gap-4">
-              <div className="flex-shrink-0 w-8 h-8 bg-green-500/20 rounded-full flex items-center justify-center">
-                <span className="text-green-400 font-bold text-lg">3</span>
-              </div>
-              <div>
-                <h3 className="text-xl font-bold text-white mb-2">Completamente libre de riesgo con empleados ilimitados</h3>
-                <p className="text-gray-300">¿No te gusta tu dashboard? Podemos construir tu propio sistema.</p>
-              </div>
-            </div>
+            ))}
           </div>
         </div>
       </div>
 
       <header className="max-w-3xl mb-10 mx-auto text-center">
         <h2 className="text-4xl md:text-5xl font-bold text-white tracking-tight">
-          Presentamos: Tus robots de Recursos Humanos
+          {t('services.robotsTitle')}
         </h2>
         <p className="mt-3 text-brand-200">
-          Reemplazá tareas repetitivas y propensas a error con <span className="text-brand-400">automatización verificable</span>.
+          <Trans i18nKey="services.robotsSubtitle" components={[<span key="0" className="text-brand-400" />]} />
         </p>
       </header>
 
-      {/* El Libro Rojo - Asistencia */}
       <div id="libro-rojo" className="mb-16">
-        <h3 className="text-2xl font-bold text-white mb-6 text-center">Pulso Laboral</h3>
+        <h3 className="text-2xl font-bold text-white mb-6 text-center">{t('services.pulsoTitle')}</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {/* SOPORTE: Asistencia */}
           <article className="group relative overflow-hidden rounded-2xl glass border border-white/15 p-6 transition-all duration-300 hover:border-brand-400/40 hover:shadow-xl hover:shadow-brand-900/30">
             <div className="flex items-center gap-3">
               <div className="h-10 w-10 grid place-items-center rounded-lg bg-white/10 border border-white/15">
                 <ClockIcon className="h-5 w-5 text-brand-300" />
               </div>
               <div>
-                <h3 className="text-xl font-bold text-white">Asistencia en tiempo real</h3>
-                <p className="text-sm text-brand-300/90">Checadas, tolerancias, alertas y bienestar</p>
+                <h3 className="text-xl font-bold text-white">{pulso.title}</h3>
+                <p className="text-sm text-brand-300/90">{pulso.desc}</p>
               </div>
             </div>
-
             <ul className="mt-4 space-y-3">
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> Tolerancia configurada + justificación inteligente</li>
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> Antifraude: patrones de tardanza y ubicación</li>
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> Pulso laboral: semáforo aleatorio (R/A/V)</li>
+              {(pulso.features as string[]).map((f) => (
+                <li key={f} className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> {f}</li>
+              ))}
             </ul>
-
           </article>
 
-          {/* SOPORTE: Reportes ejecutivos */}
           <article className="group relative overflow-hidden rounded-2xl glass border border-white/15 p-6 transition-all duration-300 hover:border-brand-400/40 hover:shadow-xl hover:shadow-brand-900/30">
             <div className="flex items-center gap-3">
               <div className="h-10 w-10 grid place-items-center rounded-lg bg-white/10 border border-white/15">
                 <CheckCircleIcon className="h-5 w-5 text-brand-300" />
               </div>
               <div>
-                <h3 className="text-xl font-bold text-white">Reportes ejecutivos</h3>
-                <p className="text-sm text-brand-300/90">Dashboard interactivo y exportación automática</p>
+                <h3 className="text-xl font-bold text-white">{reports.title}</h3>
+                <p className="text-sm text-brand-300/90">{reports.desc}</p>
               </div>
             </div>
-
             <ul className="mt-4 space-y-3">
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> Métricas en tiempo real</li>
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> Exportación Excel/PDF automática</li>
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> Alertas inteligentes y notificaciones</li>
+              {(reports.features as string[]).map((f) => (
+                <li key={f} className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> {f}</li>
+              ))}
             </ul>
-
           </article>
         </div>
       </div>
 
-      {/* El Planillero - Nómina */}
       <div id="planillero" className="mb-16">
-        <h3 className="text-2xl font-bold text-white mb-6 text-center">NominaPRO</h3>
+        <h3 className="text-2xl font-bold text-white mb-6 text-center">{t('services.nominaTitle')}</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {/* SOPORTE: Nómina sin errores */}
           <article className="group relative overflow-hidden rounded-2xl glass border border-white/15 p-6 transition-all duration-300 hover:border-brand-400/40 hover:shadow-xl hover:shadow-brand-900/30">
             <div className="flex items-center gap-3">
               <div className="h-10 w-10 grid place-items-center rounded-lg bg-white/10 border border-white/15">
                 <CurrencyDollarIcon className="h-5 w-5 text-brand-300" />
               </div>
               <div>
-                <h3 className="text-xl font-bold text-white">Nómina sin errores</h3>
-                <p className="text-sm text-brand-300/90">IHSS, RAP, ISR; PDF + vouchers por email/WhatsApp</p>
+                <h3 className="text-xl font-bold text-white">{nomina.title}</h3>
+                <p className="text-sm text-brand-300/90">{nomina.desc}</p>
               </div>
             </div>
-
             <ul className="mt-4 space-y-3">
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> Cálculo legal automático (Honduras)</li>
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> 4 horas → 4 minutos (comprobado en Paragon)</li>
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> ZIP de vouchers + envío masivo</li>
+              {(nomina.features as string[]).map((f) => (
+                <li key={f} className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> {f}</li>
+              ))}
             </ul>
-
           </article>
 
-          {/* SOPORTE: Cálculo automático */}
           <article className="group relative overflow-hidden rounded-2xl glass border border-white/15 p-6 transition-all duration-300 hover:border-brand-400/40 hover:shadow-xl hover:shadow-brand-900/30">
             <div className="flex items-center gap-3">
               <div className="h-10 w-10 grid place-items-center rounded-lg bg-white/10 border border-white/15">
                 <CurrencyDollarIcon className="h-5 w-5 text-brand-300" />
               </div>
               <div>
-                <h3 className="text-xl font-bold text-white">Cálculo automático</h3>
-                <p className="text-sm text-brand-300/90">IHSS, RAP, ISR automáticos según ley hondureña</p>
+                <h3 className="text-xl font-bold text-white">{calculo.title}</h3>
+                <p className="text-sm text-brand-300/90">{calculo.desc}</p>
               </div>
             </div>
-
             <ul className="mt-4 space-y-3">
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> Cumplimiento legal 100% automático</li>
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> Vouchers PDF + envío por email/WhatsApp</li>
-              <li className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> Auditoría completa y trazabilidad</li>
+              {(calculo.features as string[]).map((f) => (
+                <li key={f} className="flex gap-3 text-brand-200"><CheckCircleIcon className="h-5 w-5 text-brand-400" /> {f}</li>
+              ))}
             </ul>
-
           </article>
-
-
         </div>
       </div>
 
-      {/* Mini-proof bar */}
       <div className="mt-8 rounded-xl glass border border-white/10 p-6 flex flex-col items-center gap-6 text-center">
         <div className="text-brand-200">
-          <span className="text-white/90 font-medium">Prúebalo:</span>
-          <span className="flex items-center gap-2 mt-2"><CheckCircleIcon className="h-5 w-5 text-emerald-400" /> 99% menos tiempo corrigiendo errores</span>
-          <span className="flex items-center gap-2 mt-2"><CheckCircleIcon className="h-5 w-5 text-emerald-400" /> IHSS, RAP, ISR, 2025 en 1 click</span>
-          <span className="flex items-center gap-2 mt-2"><CheckCircleIcon className="h-5 w-5 text-emerald-400" /> Cumplimiento STSS desde implementación</span>
+          <span className="text-white/90 font-medium">{t('services.proof.tryIt')}</span>
+          {proofItems.map((item) => (
+            <span key={item} className="flex items-center gap-2 mt-2"><CheckCircleIcon className="h-5 w-5 text-emerald-400" /> {item}</span>
+          ))}
         </div>
-        
-        {/* Email CTA Section */}
+
         <div className="space-y-4">
           <div className="flex flex-col sm:flex-row gap-3 max-w-md">
             <input
               type="email"
-              placeholder="Tu email"
+              placeholder={t('common:cta.emailPlaceholder')}
               className="flex-1 px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-brand-200/70 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:border-transparent"
             />
             <button
-              onClick={() => window.location.href = '/activar'}
+              onClick={() => (window.location.href = '/activar')}
               className="inline-flex items-center justify-center rounded-xl px-6 py-3 text-lg font-semibold shadow-lg bg-sky-600 text-white hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400 transition-all duration-300 hover:-translate-y-0.5 whitespace-nowrap"
               data-analytics="cta_footer_click"
             >
-              Comenza HOY
+              {t('common:cta.startToday')}
             </button>
           </div>
-          
-          {/* Features text below CTA */}
+
           <div className="text-sm text-brand-200/60">
-            <p>Usalo gratis 30 días. Empleados ilimitados.</p>
+            <p>{t('common:cta.trialNote')}</p>
           </div>
         </div>
       </div>
-
-      {/* Animaciones clave globales, sin JS */}
-      <style jsx global>{`
-        @keyframes fade-up { from { opacity: 0; transform: translateY(8px) } to { opacity: 1; transform: translateY(0) } }
-        .animate-fade-up { animation: fade-up .6s ease-out both }
-      `}</style>
     </section>
   )
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -168,6 +168,30 @@ export async function middleware(request: NextRequest) {
     ip: request.headers.get('x-forwarded-for') || 'unknown'
   })
 
+  // Locale detection and redirection
+  const LOCALE_COOKIE = 'LOCALE'
+  if (!pathname.startsWith('/api') && !pathname.startsWith('/_next')) {
+    const cookieLocale = request.cookies.get(LOCALE_COOKIE)?.value
+    const pathLocale = pathname.startsWith('/en') ? 'en' : 'es'
+    let finalLocale = cookieLocale
+    if (!finalLocale) {
+      const accept = request.headers.get('accept-language') || ''
+      finalLocale = accept.split(',')[0].split('-')[0] === 'en' ? 'en' : 'es'
+    }
+    if ((pathname === '/' || pathname === '/en') && pathLocale !== finalLocale) {
+      const url = request.nextUrl.clone()
+      url.pathname = finalLocale === 'en' ? '/en' : '/'
+      const response = NextResponse.redirect(url)
+      response.cookies.set(LOCALE_COOKIE, finalLocale, { maxAge: 60 * 60 * 24 * 365 })
+      return response
+    }
+    if (!cookieLocale && (pathname === '/' || pathname === '/en')) {
+      const response = NextResponse.next()
+      response.cookies.set(LOCALE_COOKIE, finalLocale, { maxAge: 60 * 60 * 24 * 365 })
+      return response
+    }
+  }
+
   // Handle API routes
   if (pathname.startsWith('/api/')) {
     logger.debug('API route accessed', { path: pathname })

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  i18n: {
+    defaultLocale: 'es',
+    locales: ['es', 'en'],
+    localeDetection: false,
+  },
+  ns: ['common', 'landing'],
+  defaultNS: 'common',
+}

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://humano-sisu.com',
+  generateRobotsTxt: true,
+  alternateRefs: [
+    { href: process.env.NEXT_PUBLIC_SITE_URL || 'https://humano-sisu.com', hreflang: 'es' },
+    { href: (process.env.NEXT_PUBLIC_SITE_URL || 'https://humano-sisu.com') + '/en', hreflang: 'en' },
+  ],
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
+const { i18n } = require('./next-i18next.config')
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  i18n,
   
   // Configuración necesaria para Railway
   output: 'standalone',

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,8 @@
         "luxon": "^3.6.1",
         "multiparty": "^4.2.3",
         "next": "^15.4.3",
+        "next-i18next": "^15.4.2",
+        "next-sitemap": "^4.2.3",
         "node-cron": "^3.0.3",
         "node-fetch": "^3.3.2",
         "nodemailer": "^7.0.5",
@@ -917,6 +919,12 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
+      "license": "MIT"
     },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.3",
@@ -3807,6 +3815,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -5607,6 +5627,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -7772,6 +7803,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -7813,6 +7854,44 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/i18next": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.5.2.tgz",
+      "integrity": "sha512-lW8Zeh37i/o0zVr+NoCHfNnfvVw+M6FQbRp36ZZ/NyHDJ3NJVpp2HhAUyU9WafL5AssymNoOjMRB48mmx2P6Hw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-fs-backend": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.0.tgz",
+      "integrity": "sha512-3ZlhNoF9yxnM8pa8bWp5120/Ob6t4lVl1l/tbLmkml/ei3ud8IWySCHt2lrY5xWRlSU5D9IV2sm5bEbGuTqwTw==",
+      "license": "MIT"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -9466,6 +9545,75 @@
         }
       }
     },
+    "node_modules/next-i18next": {
+      "version": "15.4.2",
+      "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-15.4.2.tgz",
+      "integrity": "sha512-zgRxWf7kdXtM686ecGIBQL+Bq0+DqAhRlasRZ3vVF0TmrNTWkVhs52n//oU3Fj5O7r/xOKkECDUwfOuXVwTK/g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@types/hoist-non-react-statics": "^3.3.6",
+        "core-js": "^3",
+        "hoist-non-react-statics": "^3.3.2",
+        "i18next-fs-backend": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.7.13",
+        "next": ">= 12.0.0",
+        "react": ">= 17.0.2",
+        "react-i18next": ">= 13.5.0"
+      }
+    },
+    "node_modules/next-sitemap": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
+      "integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.43",
+        "@next/env": "^13.4.3",
+        "fast-glob": "^3.2.12",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "next": "*"
+      }
+    },
+    "node_modules/next-sitemap/node_modules/@next/env": {
+      "version": "13.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
+      "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
+      "license": "MIT"
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -10248,6 +10396,33 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.3.tgz",
+      "integrity": "sha512-AANws4tOE+QSq/IeMF/ncoHlMNZaVLxpa5uUGW1wjike68elVYr0018L9xYoqBr1OFO7G7boDPrbn0HpMCJxTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.4.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -12278,6 +12453,16 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "luxon": "^3.6.1",
     "multiparty": "^4.2.3",
     "next": "^15.4.3",
+    "next-i18next": "^15.4.2",
+    "next-sitemap": "^4.2.3",
     "node-cron": "^3.0.3",
     "node-fetch": "^3.3.2",
     "nodemailer": "^7.0.5",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { AppProps } from 'next/app'
+import { appWithTranslation } from 'next-i18next'
 import { createClient } from '../lib/supabase/client'
 import { createContext, useState, useEffect } from 'react'
 import { AuthProvider } from '../lib/auth'
@@ -33,7 +34,7 @@ async function loadEnvironmentVariables() {
   return null
 }
 
-export default function App({ Component, pageProps }: AppProps) {
+function App({ Component, pageProps }: AppProps) {
   const [supabaseClient, setSupabaseClient] = useState<any>(null)
   const [envLoaded, setEnvLoaded] = useState(false)
 
@@ -72,3 +73,5 @@ export default function App({ Component, pageProps }: AppProps) {
     </SupabaseContext.Provider>
   )
 }
+
+export default appWithTranslation(App)

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,13 +1,27 @@
-import { Html, Head, Main, NextScript } from 'next/document'
+import { Html, Head, Main, NextScript, DocumentProps } from 'next/document'
 
-export default function Document() {
+export default function Document(props: DocumentProps) {
+  const locale = props.locale || 'es'
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || ''
+  const path = props.__NEXT_DATA__.page === '/' ? '' : props.__NEXT_DATA__.page
+  const localePath = locale === 'es' ? '' : `/${locale}`
+  const canonical = baseUrl ? `${baseUrl}${localePath}${path}` : undefined
+
   return (
-    <Html lang="es">
-      <Head />
+    <Html lang={locale}>
+      <Head>
+        {baseUrl && (
+          <>
+            {canonical && <link rel="canonical" href={canonical} />}
+            <link rel="alternate" hrefLang="es" href={`${baseUrl}${path}`} />
+            <link rel="alternate" hrefLang="en" href={`${baseUrl}/en${path}`} />
+          </>
+        )}
+      </Head>
       <body>
         <Main />
         <NextScript />
       </body>
     </Html>
   )
-} 
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,8 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import { useState, useEffect } from 'react'
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import DemoFooter from '../components/DemoFooter'
 import ServicesSection from '../components/ServicesSection'
 import AWSCertificationsSection from '../components/AWSCertificationsSection'
@@ -8,12 +10,14 @@ import LandingHero from '../components/LandingHero'
 import CountdownTimer from '../components/CountdownTimer'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
+import LanguageSwitcher from '../components/LanguageSwitcher'
 
 const CloudBackground = dynamic(() => import('../components/CloudBackground'), { ssr: false })
 
 export default function LandingPage() {
   const [isScrolled, setIsScrolled] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const { t } = useTranslation(['common', 'landing'])
 
   useEffect(() => {
     const handleScroll = () => {
@@ -32,27 +36,24 @@ export default function LandingPage() {
       if (element) element.scrollIntoView({ behavior: 'smooth' })
     }
   }
+  const badges = t('trustBadges', { returnObjects: true }) as string[]
 
   return (
     <div className="min-h-screen bg-app pt-20 relative">
       <Head>
-        <title>¿Otra quincena corriendo detrás de la planilla? | Humano SISU</title>
-        <meta
-          name="description"
-          content="Generá planilla en 5 minutos con IHSS, RAP e ISR listos y vouchers enviados por WhatsApp. Cumplimiento STSS, de Excel caótico a PDF impecable."
-        />
-        <meta name="keywords" content="planilla Honduras, IHSS, RAP, ISR, automatización RH, STSS, Humano SISU, innovación" />
-        <meta name="author" content="Humano SISU" />
+        <title>{t('head.title')}</title>
+        <meta name="description" content={t('head.description')} />
+        <meta name="keywords" content={t('head.keywords')} />
+        <meta name="author" content={t('head.author')} />
         <meta name="robots" content="index, follow" />
-        <meta property="og:title" content="Humano SISU - Automatización de Planilla en Honduras" />
-        <meta property="og:description" content="Generá planilla en 5 minutos con IHSS, RAP e ISR listos. Cumplimiento STSS garantizado." />
+        <meta property="og:title" content={t('head.ogTitle')} />
+        <meta property="og:description" content={t('head.ogDescription')} />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://humano-sisu.com" />
+        <meta property="og:url" content={process.env.NEXT_PUBLIC_SITE_URL} />
         <meta property="og:image" content="/logo-humano-sisu.png" />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Humano SISU - Automatización de Planilla" />
-        <meta name="twitter:description" content="Generá planilla en 5 minutos con IHSS, RAP e ISR listos." />
-        <link rel="canonical" href="https://humano-sisu.com" />
+        <meta name="twitter:title" content={t('head.twitterTitle')} />
+        <meta name="twitter:description" content={t('head.twitterDescription')} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
       </Head>
@@ -84,9 +85,9 @@ export default function LandingPage() {
               
               {/* Título */}
               <h1 className="text-lg sm:text-xl md:text-2xl lg:text-3xl xl:text-4xl font-bold text-white leading-tight ml-2 flex-shrink-0 text-left">
-                <span className="text-white">Recursos Humanos en Automatico</span>
+                <span className="text-white">{t('header.tagline.main')}</span>
                 <span className="hidden sm:inline"> </span>
-                <span className="text-brand-300">activa, cumplí y ahorrá horas cada semana</span>
+                <span className="text-brand-300">{t('header.tagline.highlight')}</span>
               </h1>
 
               <div className="hidden md:block ml-auto">
@@ -96,14 +97,15 @@ export default function LandingPage() {
                     className="text-brand-200 hover:text-white px-3 py-2 rounded-full text-sm font-medium transition-all duration-300 hover:bg-white/10 hover:-translate-y-0.5 active:translate-y-0 whitespace-nowrap"
                     onClick={scrollToSection}
                   >
-                    Servicios
+                    {t('common:nav.services')}
                   </a>
                   <Link
                     href="/app/login"
                     className="bg-brand-600 hover:bg-brand-700 text-white px-6 py-2.5 rounded-lg text-sm font-medium transition-all duration-300 shadow-lg shadow-black/20 hover:-translate-y-0.5 active:translate-y-0 whitespace-nowrap min-w-[140px] text-center"
                   >
-                    Iniciar sesión
+                    {t('common:nav.login')}
                   </Link>
+                  <LanguageSwitcher />
                 </div>
               </div>
 
@@ -113,7 +115,7 @@ export default function LandingPage() {
                   onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
                   className="glass inline-flex items-center justify-center p-2 rounded-md text-brand-200 hover:text-white hover:bg-brand-700/20 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
                 >
-                  <span className="sr-only">Open main menu</span>
+                  <span className="sr-only">{t('common:nav.openMenu')}</span>
                   {isMobileMenuOpen ? (
                     <svg className="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -140,15 +142,16 @@ export default function LandingPage() {
                   className="block px-3 py-2 text-base font-medium text-brand-200/90 hover:text-white hover:bg-brand-800/20 rounded-md transition-colors"
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
-                  Servicios
+                  {t('common:nav.services')}
                 </a>
                 <Link
                   href="/app/login"
                   className="bg-brand-900 hover:bg-brand-800 text-white w-full text-center block py-2 px-4 rounded-lg transition-colors"
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
-                  Iniciar sesión
+                  {t('common:nav.login')}
                 </Link>
+                <LanguageSwitcher />
               </div>
             </div>
           )}
@@ -160,9 +163,14 @@ export default function LandingPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           {/* Trust badges */}
           <div className="flex flex-wrap justify-center gap-3 md:gap-6 mb-8 animate-fade-up-subtle">
-            <span className="text-sm bg-green-500/10 text-green-400 px-3 py-1 rounded-full border border-green-500/20 hover:bg-green-500/20 transition-all duration-300 hover:-translate-y-0.5 animate-delay-100">Cumple STSS Honduras</span>
-            <span className="text-sm bg-blue-500/10 text-blue-400 px-3 py-1 rounded-full border border-blue-500/20 hover:bg-blue-500/20 transition-all duration-300 hover:-translate-y-0.5 animate-delay-200">Setup en 24 horas</span>
-            <span className="text-sm bg-orange-500/10 text-orange-400 px-3 py-1 rounded-full border border-orange-500/20 hover:bg-orange-500/20 transition-all duration-300 hover:-translate-y-0.5 animate-delay-300">02 empresas activas</span>
+            {badges.map((badge, i) => (
+              <span
+                key={badge}
+                className={`text-sm px-3 py-1 rounded-full border transition-all duration-300 hover:-translate-y-0.5 animate-delay-${(i + 1) * 100}`}
+              >
+                {badge}
+              </span>
+            ))}
           </div>
 
           {/* Countdown Timer - Centrado debajo de los trust badges */}
@@ -187,15 +195,11 @@ export default function LandingPage() {
       <section id="servicios" className="py-16 bg-white/5">
         <div className="max-w-6xl mx-auto px-4">
           <h2 className="text-3xl font-bold text-center text-white mb-12">
-            Empresas que ya automatizaron su RH
+            {t('socialProof.title')}
           </h2>
 
           <div className="grid md:grid-cols-3 gap-8">
-            {[
-              { name: 'Felix Garcia', company: 'Tony\'s Mar Restaurant', employees: '40 empleados', quote: 'Ya no pierdo domingos haciendo planilla. 4 horas ahora son 4 minutos.' },
-              { name: 'Gustavo Argueta', company: 'Paragon Honduras', employees: '37 empleados', quote: 'Antes llevavamos la asistencia en un libro rojo, ahora tneemos dashboard interactivo.' },
-              { name: 'Luis Diego Maradiaga', company: 'AFI & Asociados', employees: '15 empleados', quote: 'Cero errores en IHSS desde que lo uso. Mi contador está feliz.' }
-            ].map((testimonial, i) => (
+            {(t('socialProof.testimonials', { returnObjects: true }) as any[]).map((testimonial, i) => (
               <div key={`testimonial-${i}`} className="bg-white/5 border border-white/10 rounded-xl p-6">
                 <div className="flex items-center gap-3 mb-4">
                   <div className="w-12 h-12 bg-brand-500 rounded-full flex items-center justify-center text-white font-bold">
@@ -223,18 +227,16 @@ export default function LandingPage() {
       <footer className="border-t border-white/10 mt-20">
         <div className="max-w-6xl mx-auto px-4 py-12">
           <div className="text-center">
-            <p className="text-slate-400 mb-4">
-              Protegemos tu información. <strong>Solo será utilizadapara contactarte</strong>.
-            </p>
+            <p className="text-slate-400 mb-4" dangerouslySetInnerHTML={{ __html: t('common:footer.protect') }} />
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center text-sm">
-              <Link 
-                href="/politicadeprivacidad" 
+              <Link
+                href="/politicadeprivacidad"
                 className="text-brand-300 hover:text-brand-400 transition-colors underline decoration-brand-400/30 hover:decoration-brand-400"
               >
-                Política de Privacidad
+                {t('common:footer.privacy')}
               </Link>
               <span className="text-slate-500">•</span>
-              <span className="text-slate-500">© 2025 Humano SISU. Todos los derechos reservados.</span>
+              <span className="text-slate-500">{t('common:footer.rights')}</span>
             </div>
           </div>
         </div>
@@ -243,4 +245,12 @@ export default function LandingPage() {
       <DemoFooter />
     </div>
   )
+}
+
+export async function getStaticProps({ locale }: { locale: string }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common', 'landing'])),
+    },
+  }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,21 @@
+{
+  "nav": {
+    "services": "Services",
+    "login": "Log in",
+    "openMenu": "Open main menu"
+  },
+  "language": {
+    "en": "EN",
+    "es": "ES"
+  },
+  "cta": {
+    "emailPlaceholder": "Your email",
+    "startToday": "Start Today",
+    "trialNote": "Use it free for 30 days. Unlimited employees."
+  },
+  "footer": {
+    "protect": "We protect your information. <strong>It will only be used to contact you</strong>.",
+    "privacy": "Privacy Policy",
+    "rights": "© 2025 Humano SISU. All rights reserved."
+  }
+}

--- a/public/locales/en/landing.json
+++ b/public/locales/en/landing.json
@@ -1,0 +1,141 @@
+{
+  "head": {
+    "title": "Another pay period chasing payroll? | Humano SISU",
+    "description": "Generate payroll in 5 minutes with IHSS, RAP and ISR ready and vouchers sent via WhatsApp. STSS compliance, from chaotic Excel to flawless PDF.",
+    "keywords": "payroll Honduras, IHSS, RAP, ISR, HR automation, STSS, Humano SISU, innovation",
+    "author": "Humano SISU",
+    "ogTitle": "Humano SISU - Payroll Automation in Honduras",
+    "ogDescription": "Generate payroll in 5 minutes with IHSS, RAP and ISR ready. STSS compliance guaranteed.",
+    "twitterTitle": "Humano SISU - Payroll Automation",
+    "twitterDescription": "Generate payroll in 5 minutes with IHSS, RAP and ISR ready."
+  },
+  "header": {
+    "tagline": {
+      "main": "Human Resources on Autopilot",
+      "highlight": "activate, comply and save hours every week"
+    }
+  },
+  "trustBadges": ["Complies with STSS Honduras", "Setup in 24 hours", "02 active companies"],
+  "hero": {
+    "title": "Always running behind HR tasks?",
+    "subtitle": "Swap them for robots and forget about the rush forever.",
+    "description": "Generate payroll in 5 minutes with IHSS, RAP and ISR ready and vouchers sent by Mail/WhatsApp.",
+    "bullets": [
+      "STSS compliance from day one.",
+      "From chaotic Excel to flawless PDF in minutes.",
+      "Save 6 hours every pay period."
+    ],
+    "nextPayroll": "Next payroll: {{date}}. Will you do it from scratch again?"
+  },
+  "countdown": {
+    "title": "YOUR NEXT PAYDAY IS IN",
+    "labels": {"days": "DAYS", "hours": "HOURS", "minutes": "MIN", "seconds": "SEC"}
+  },
+  "services": {
+    "howItWorks": "HOW IT WORKS",
+    "replace": "Replace costly internal teams and unreliable consultants with a flat monthly fee",
+    "steps": [
+      {"title": "No more hiring, managing or dealing with HR staff", "desc": "We automate 80% of HR operations for you."},
+      {"title": "Extraordinarily simple to use", "desc": "Add your specific parameters and we handle the rest."},
+      {"title": "Completely risk free with unlimited employees", "desc": "Don't like your dashboard? We can build your own system."}
+    ],
+    "robotsTitle": "Introducing: Your Human Resources robots",
+    "robotsSubtitle": "Replace repetitive, error-prone tasks with <1>verifiable automation</1>.",
+    "pulsoTitle": "Labor Pulse",
+    "pulso": {
+      "title": "Real-time attendance",
+      "desc": "Check-ins, tolerances, alerts and wellbeing",
+      "features": [
+        "Configured tolerance + smart justification",
+        "Anti-fraud: tardiness patterns and location",
+        "Labor pulse: random traffic light (R/Y/G)"
+      ]
+    },
+    "reports": {
+      "title": "Executive reports",
+      "desc": "Interactive dashboard and automatic export",
+      "features": [
+        "Real-time metrics",
+        "Automatic Excel/PDF export",
+        "Smart alerts and notifications"
+      ]
+    },
+    "nominaTitle": "NominaPRO",
+    "nomina": {
+      "title": "Error-free payroll",
+      "desc": "IHSS, RAP, ISR; PDF + vouchers by email/WhatsApp",
+      "features": [
+        "Automatic legal calculation (Honduras)",
+        "4 hours → 4 minutes (proven at Paragon)",
+        "ZIP of vouchers + bulk sending"
+      ]
+    },
+    "calculo": {
+      "title": "Automatic calculation",
+      "desc": "IHSS, RAP, ISR automatic according to Honduran law",
+      "features": [
+        "100% automatic legal compliance",
+        "PDF vouchers + email/WhatsApp delivery",
+        "Complete audit and traceability"
+      ]
+    },
+    "proof": {
+      "tryIt": "Try it:",
+      "items": [
+        "99% less time fixing errors",
+        "IHSS, RAP, ISR 2025 in 1 click",
+        "STSS compliance from implementation"
+      ],
+      "note": "Use it free for 30 days. Unlimited employees."
+    }
+  },
+  "aws": {
+    "title": "Built by AWS certified engineers",
+    "tagline1": "Made with the same technology used by Netflix and Airbnb, now for your MSME in Honduras",
+    "tagline2": "Optimized so your company in Honduras has the security and scalability of a giant without paying like one.",
+    "tagline3": "Global technology. Local price.",
+    "certifications": [
+      {"name": "AWS Solutions Architect", "icon": "/image-aws-solutions-architect.png", "badgeColor": "bg-blue-500/10 text-blue-400 border-blue-500/20"},
+      {"name": "AWS Developer", "icon": "/image-aws-developer.png", "badgeColor": "bg-blue-500/10 text-blue-400 border-blue-500/20"},
+      {"name": "AWS Cloud Practitioner", "icon": "/image-aws-cloud-practitioner.png", "badgeColor": "bg-gray-400/10 text-gray-300 border-gray-400/20"}
+    ],
+    "guarantee": "Quality and security guaranteed by AWS certification"
+  },
+  "socialProof": {
+    "title": "Companies that already automated their HR",
+    "testimonials": [
+      {
+        "name": "Felix Garcia",
+        "company": "Tony's Mar Restaurant",
+        "employees": "40 employees",
+        "quote": "I no longer lose Sundays doing payroll. 4 hours are now 4 minutes."
+      },
+      {
+        "name": "Gustavo Argueta",
+        "company": "Paragon Honduras",
+        "employees": "37 employees",
+        "quote": "We used to track attendance in a red book, now we have an interactive dashboard."
+      },
+      {
+        "name": "Luis Diego Maradiaga",
+        "company": "AFI & Asociados",
+        "employees": "15 employees",
+        "quote": "Zero IHSS errors since I use it. My accountant is happy."
+      }
+    ]
+  },
+  "demoFooter": {
+    "contact": "Contact",
+    "community": {
+      "title": "Join the Community",
+      "text": "Follow us on social media to know the latest updates"
+    },
+    "about": {
+      "title": "Humano SISU",
+      "desc": "Your HR 100% digital, legal and hassle-free. Made for SMEs like yours.",
+      "rights1": "© 2025 Humano SISU",
+      "rights2": "Human Resources System"
+    },
+    "whatsapp": "WhatsApp: 9470-7007"
+  }
+}

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,0 +1,21 @@
+{
+  "nav": {
+    "services": "Servicios",
+    "login": "Iniciar sesión",
+    "openMenu": "Abrir menú principal"
+  },
+  "language": {
+    "en": "EN",
+    "es": "ES"
+  },
+  "cta": {
+    "emailPlaceholder": "Tu email",
+    "startToday": "Comenza HOY",
+    "trialNote": "Usalo gratis 30 días. Empleados ilimitados."
+  },
+  "footer": {
+    "protect": "Protegemos tu información. <strong>Solo será utilizada para contactarte</strong>.",
+    "privacy": "Política de Privacidad",
+    "rights": "© 2025 Humano SISU. Todos los derechos reservados."
+  }
+}

--- a/public/locales/es/landing.json
+++ b/public/locales/es/landing.json
@@ -1,0 +1,141 @@
+{
+  "head": {
+    "title": "¿Otra quincena corriendo detrás de la planilla? | Humano SISU",
+    "description": "Generá planilla en 5 minutos con IHSS, RAP e ISR listos y vouchers enviados por WhatsApp. Cumplimiento STSS, de Excel caótico a PDF impecable.",
+    "keywords": "planilla Honduras, IHSS, RAP, ISR, automatización RH, STSS, Humano SISU, innovación",
+    "author": "Humano SISU",
+    "ogTitle": "Humano SISU - Automatización de Planilla en Honduras",
+    "ogDescription": "Generá planilla en 5 minutos con IHSS, RAP e ISR listos. Cumplimiento STSS garantizado.",
+    "twitterTitle": "Humano SISU - Automatización de Planilla",
+    "twitterDescription": "Generá planilla en 5 minutos con IHSS, RAP e ISR listos."
+  },
+  "header": {
+    "tagline": {
+      "main": "Recursos Humanos en Automatico",
+      "highlight": "activa, cumplí y ahorrá horas cada semana"
+    }
+  },
+  "trustBadges": ["Cumple STSS Honduras", "Setup en 24 horas", "02 empresas activas"],
+  "hero": {
+    "title": "¿Siempre corriendo detras de Recursos Humanos?",
+    "subtitle": "Cambialos por robots y olvidate de las carreras para siempre.",
+    "description": "Generá planilla en 5 minutos, con IHSS, RAP e ISR listos y vouchers enviados por Mail/WhatsApp.",
+    "bullets": [
+      "Cumplimiento STSS desde el día uno.",
+      "De Excel caótico a PDF impecable en minutos.",
+      "Ahorro de 6 horas por quincena."
+    ],
+    "nextPayroll": "Próxima planilla: {{date}}. ¿Otra vez la vas a hacer desde cero?"
+  },
+  "countdown": {
+    "title": "TU PROXIMA FECHA DE PAGO ES EN",
+    "labels": {"days": "DÍAS", "hours": "HORAS", "minutes": "MIN", "seconds": "SEG"}
+  },
+  "services": {
+    "howItWorks": "CÓMO FUNCIONA",
+    "replace": "Reemplazá equipos internos costosos y consultores poco confiables por una tarifa mensual fija",
+    "steps": [
+      {"title": "No más contratar, gestionar o lidiar con personal de RH", "desc": "Automatizamos el 80% de las operaciones de Recursos Humanos por vos."},
+      {"title": "Extraordinariamente simple de usar", "desc": "Agregá los parámetros específicos de tu caso de uso y nosotros nos encargamos del resto."},
+      {"title": "Completamente libre de riesgo con empleados ilimitados", "desc": "¿No te gusta tu dashboard? Podemos construir tu propio sistema."}
+    ],
+    "robotsTitle": "Presentamos: Tus robots de Recursos Humanos",
+    "robotsSubtitle": "Reemplazá tareas repetitivas y propensas a error con <1>automatización verificable</1>.",
+    "pulsoTitle": "Pulso Laboral",
+    "pulso": {
+      "title": "Asistencia en tiempo real",
+      "desc": "Checadas, tolerancias, alertas y bienestar",
+      "features": [
+        "Tolerancia configurada + justificación inteligente",
+        "Antifraude: patrones de tardanza y ubicación",
+        "Pulso laboral: semáforo aleatorio (R/A/V)"
+      ]
+    },
+    "reports": {
+      "title": "Reportes ejecutivos",
+      "desc": "Dashboard interactivo y exportación automática",
+      "features": [
+        "Métricas en tiempo real",
+        "Exportación Excel/PDF automática",
+        "Alertas inteligentes y notificaciones"
+      ]
+    },
+    "nominaTitle": "NominaPRO",
+    "nomina": {
+      "title": "Nómina sin errores",
+      "desc": "IHSS, RAP, ISR; PDF + vouchers por email/WhatsApp",
+      "features": [
+        "Cálculo legal automático (Honduras)",
+        "4 horas → 4 minutos (comprobado en Paragon)",
+        "ZIP de vouchers + envío masivo"
+      ]
+    },
+    "calculo": {
+      "title": "Cálculo automático",
+      "desc": "IHSS, RAP, ISR automáticos según ley hondureña",
+      "features": [
+        "Cumplimiento legal 100% automático",
+        "Vouchers PDF + envío por email/WhatsApp",
+        "Auditoría completa y trazabilidad"
+      ]
+    },
+    "proof": {
+      "tryIt": "Prúebalo:",
+      "items": [
+        "99% menos tiempo corrigiendo errores",
+        "IHSS, RAP, ISR 2025 en 1 click",
+        "Cumplimiento STSS desde implementación"
+      ],
+      "note": "Usalo gratis 30 días. Empleados ilimitados."
+    }
+  },
+  "aws": {
+    "title": "Desarrollado por ingenieros certificados en AWS",
+    "tagline1": "Hecho con la misma tecnología que usan Netflix y Airbnb, ahora para tu MIPYMES en Honduras",
+    "tagline2": "Optimizado para que tu empresa en Honduras tenga la seguridad y escalabilidad de un gigante, sin pagar como uno.",
+    "tagline3": "Tecnología global. Precio local.",
+    "certifications": [
+      {"name": "AWS Solutions Architect", "icon": "/image-aws-solutions-architect.png", "badgeColor": "bg-blue-500/10 text-blue-400 border-blue-500/20"},
+      {"name": "AWS Developer", "icon": "/image-aws-developer.png", "badgeColor": "bg-blue-500/10 text-blue-400 border-blue-500/20"},
+      {"name": "AWS Cloud Practitioner", "icon": "/image-aws-cloud-practitioner.png", "badgeColor": "bg-gray-400/10 text-gray-300 border-gray-400/20"}
+    ],
+    "guarantee": "Garantía de calidad y seguridad certificada por AWS"
+  },
+  "socialProof": {
+    "title": "Empresas que ya automatizaron su RH",
+    "testimonials": [
+      {
+        "name": "Felix Garcia",
+        "company": "Tony's Mar Restaurant",
+        "employees": "40 empleados",
+        "quote": "Ya no pierdo domingos haciendo planilla. 4 horas ahora son 4 minutos."
+      },
+      {
+        "name": "Gustavo Argueta",
+        "company": "Paragon Honduras",
+        "employees": "37 empleados",
+        "quote": "Antes llevavamos la asistencia en un libro rojo, ahora tneemos dashboard interactivo."
+      },
+      {
+        "name": "Luis Diego Maradiaga",
+        "company": "AFI & Asociados",
+        "employees": "15 empleados",
+        "quote": "Cero errores en IHSS desde que lo uso. Mi contador está feliz."
+      }
+    ]
+  },
+  "demoFooter": {
+    "contact": "Contacto",
+    "community": {
+      "title": "Únete a la Comunidad",
+      "text": "Síguenos en nuestras redes sociales para conocer las últimas actualizaciones"
+    },
+    "about": {
+      "title": "Humano SISU",
+      "desc": "Tu RH 100% digital, legal y sin complicaciones. Hecho para PYMEs como la tuya.",
+      "rights1": "© 2025 Humano SISU",
+      "rights2": "Sistema de Recursos Humanos"
+    },
+    "whatsapp": "WhatsApp: 9470-7007"
+  }
+}


### PR DESCRIPTION
## Summary
- integrate next-i18next and configure Next.js i18n with locale detection disabled
- add language switcher, middleware locale redirection, and sitemap with alternate refs
- extract landing page copy into JSON translations for es/en and use appWithTranslation

## Testing
- `npm test` *(fails: Cannot find package '@playwright/test')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bde0d983f8832998c233c525215192