### PR TITLE
Cubo A: candado de tenant en 5 rutas sin tocar el producto

### DIFF
--- a/middleware.config.ts
+++ b/middleware.config.ts
@@ -156,7 +156,6 @@ export function getAllPublicRoutes(): string[] {
     '/api/attendance/lookup',
     '/api/attendance/register',
     '/api/attendance/first-time-check',
-    '/api/attendance/update-schedule',
     '/api/activar',
     '/api/demo/verify-pin',
     '/api/health',

--- a/pages/api/attendance/kpis-unified.ts
+++ b/pages/api/attendance/kpis-unified.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { requireCompanyAccess } from '../../../lib/auth/api-auth-fixed'
 import { createAdminClient } from '../../../lib/supabase/server'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -7,32 +8,59 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const { 
-    preset = 'today', 
-    employee_id = null,
-    tz = 'America/Tegucigalpa',
-    week_start = '1',
-    company_id = '00000000-0000-0000-0000-000000000001'
-  } = req.query
+  try {
+    const { companyId } = await requireCompanyAccess(req, res)
+    if (!companyId) return res.status(400).json({ error: 'Company access required' })
 
-  const supabase = createAdminClient()
-  
-  const rpcArgs = {
-    _company_id: company_id as string,
-    _employee_id: (typeof employee_id === 'string' && employee_id.trim() !== '') ? employee_id.trim() : undefined,
-    _preset: preset as string,
-    _tz: tz as string,
-    _week_start: parseInt(week_start as string, 10)
+    const {
+      preset = 'today',
+      employee_id = null,
+      tz = 'America/Tegucigalpa',
+      week_start = '1',
+    } = req.query
+
+    const supabase = createAdminClient()
+
+    const employeeId =
+      typeof employee_id === 'string' && employee_id.trim() !== '' ? employee_id.trim() : undefined
+
+    if (employeeId) {
+      const { data: employee, error: employeeError } = await supabase
+        .from('employees')
+        .select('id')
+        .eq('id', employeeId)
+        .eq('company_id', companyId)
+        .maybeSingle()
+      if (employeeError) {
+        console.error('attendance_kpis_unified employee lookup error', employeeError)
+        return res.status(500).json({ error: employeeError.message })
+      }
+      if (!employee) {
+        return res.status(404).json({ error: 'Employee not found' })
+      }
+    }
+
+    const rpcArgs = {
+      _company_id: companyId,
+      _employee_id: employeeId,
+      _preset: preset as string,
+      _tz: tz as string,
+      _week_start: parseInt(week_start as string, 10)
+    }
+
+    console.log('Unified RPC Args:', rpcArgs)
+
+    const { data, error } = await supabase.rpc('attendance_kpis_unified', rpcArgs)
+
+    if (error) {
+      console.error('attendance_kpis_unified error', error)
+      return res.status(500).json({ error: error.message })
+    }
+
+    return res.status(200).json(data)
+  } catch (e: any) {
+    if (res.headersSent) return
+    console.error('attendance_kpis_unified error', e)
+    return res.status(500).json({ error: e?.message || 'Internal error' })
   }
-
-  console.log('Unified RPC Args:', rpcArgs)
-
-  const { data, error } = await supabase.rpc('attendance_kpis_unified', rpcArgs)
-
-  if (error) {
-    console.error('attendance_kpis_unified error', error)
-    return res.status(500).json({ error: error.message })
-  }
-
-  res.status(200).json(data)
 }

--- a/pages/api/attendance/update-schedule.ts
+++ b/pages/api/attendance/update-schedule.ts
@@ -1,6 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next'
+import { requireCompanyAccess } from '../../../lib/auth/api-auth-fixed'
 import { createAdminClient } from '../../../lib/supabase/server'
 import { getHondurasTimeISO } from '../../../lib/timezone'
+
+const SCHEDULE_ROLES = ['super_admin', 'company_admin', 'hr_manager']
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -8,6 +11,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
+    const { companyId, role } = await requireCompanyAccess(req, res)
+    if (!companyId) return res.status(400).json({ error: 'Company access required' })
+    if (!SCHEDULE_ROLES.includes(role)) {
+      return res.status(403).json({ error: 'Insufficient permissions' })
+    }
+
     const { employee_id, start_time, end_time } = req.body
 
     if (!employee_id || !start_time || !end_time) {
@@ -19,11 +28,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // First, check if employee exists
     const { data: employee, error: empError } = await supabase
       .from('employees')
-      .select('*')
+      .select('id, name, company_id, work_schedule_id')
       .eq('id', employee_id)
+      .eq('company_id', companyId)
       .single()
 
-    if (empError || !employee) {
+    if (empError || !employee || employee.company_id !== companyId) {
       return res.status(404).json({ error: 'Employee not found' })
     }
 
@@ -128,10 +138,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     })
 
   } catch (error) {
+    if (res.headersSent) return
     console.error('Error updating schedule:', error)
     res.status(500).json({ 
       error: 'Internal server error', 
       details: error instanceof Error ? error.message : 'Error desconocido'
     })
   }
-} 
+}

--- a/pages/api/hikvision/status/[deviceId].ts
+++ b/pages/api/hikvision/status/[deviceId].ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { requireCompanyAccess } from '../../../../lib/auth/api-auth-fixed';
 import { createAdminClient } from '../../../../lib/supabase/server';
 
 /**
@@ -19,12 +20,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   console.log(`[Hikvision Proxy] Received status request for device ${deviceId}`);
 
   try {
+    const { companyId, role } = await requireCompanyAccess(req, res);
+    if (!companyId) return res.status(400).json({ error: 'Company access required' });
+    if (!['company_admin', 'super_admin'].includes(role)) {
+      return res.status(403).json({ error: 'Insufficient permissions' });
+    }
+
     const supabase = createAdminClient();
 
     const { data: device, error } = await supabase
       .from('devices')
-      .select('id, name, status, last_sync_at, last_event_at, ip_address, webhook_url')
+      .select('id, name, status, last_sync_at, last_event_at')
       .eq('id', deviceId)
+      .eq('company_id', companyId)
       .single();
 
     if (error || !device) {
@@ -37,11 +45,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     console.log(`[Hikvision Proxy] Returning stored status for device ${deviceId}: ${device.status}`);
 
-    return res.status(200).json(device);
+    return res.status(200).json({
+      id: device.id,
+      name: device.name,
+      status: device.status,
+      last_sync_at: device.last_sync_at,
+      last_event_at: device.last_event_at,
+    });
 
   } catch (err: any) {
+    if (res.headersSent) return;
     console.error(`[Hikvision Proxy] An unexpected error occurred during status check for device ${deviceId}`, err);
     res.status(500).json({ error: 'Internal server error occurred.' });
   }
 }
-

--- a/pages/api/payroll/compare.ts
+++ b/pages/api/payroll/compare.ts
@@ -1,10 +1,19 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { requireCompanyAccess } from '../../../lib/auth/api-auth-fixed'
 import { createAdminClient } from '../../../lib/supabase/server'
 import { getHondurasTimestamp } from '../../../lib/timezone'
+
+const PAYROLL_ROLES = ['super_admin', 'company_admin', 'hr_manager', 'hr_analyst']
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
   try {
+    const { companyId, role } = await requireCompanyAccess(req, res)
+    if (!companyId) return res.status(400).json({ error: 'Company access required' })
+    if (!PAYROLL_ROLES.includes(role)) {
+      return res.status(403).json({ error: 'Insufficient permissions' })
+    }
+
     const { periodo = getHondurasTimestamp().slice(0,7), quincena = '1' } = req.query
     const supabase = createAdminClient()
 
@@ -26,7 +35,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const sumForRange = async (range: {start:string; end:string}) => {
       const { data, error } = await supabase
         .from('payroll_records')
-        .select('gross_salary, total_deductions, net_salary')
+        .select('gross_salary, total_deductions, net_salary, employees!payroll_records_employee_id_fkey!inner(company_id)')
+        .eq('employees.company_id', companyId)
         .gte('period_start', range.start)
         .lt('period_end', range.end)
       if (error) throw new Error(error.message)
@@ -43,8 +53,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
     return res.status(200).json({ periodo, quincena: q, prev_periodo: prevYm, current: curr, previous: prev, delta })
   } catch (e: any) {
+    if (res.headersSent) return
     return res.status(500).json({ error: e?.message || 'Internal error' })
   }
 }
-
-

--- a/pages/api/payroll/trend.ts
+++ b/pages/api/payroll/trend.ts
@@ -1,10 +1,19 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { requireCompanyAccess } from '../../../lib/auth/api-auth-fixed'
 import { createAdminClient } from '../../../lib/supabase/server'
 import { nowInHonduras } from '../../../lib/timezone'
+
+const PAYROLL_ROLES = ['super_admin', 'company_admin', 'hr_manager', 'hr_analyst']
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
   try {
+    const { companyId, role } = await requireCompanyAccess(req, res)
+    if (!companyId) return res.status(400).json({ error: 'Company access required' })
+    if (!PAYROLL_ROLES.includes(role)) {
+      return res.status(403).json({ error: 'Insufficient permissions' })
+    }
+
     const { months = '6' } = req.query
     const supabase = createAdminClient()
     const m = Math.max(1, Math.min(24, parseInt(String(months), 10) || 6))
@@ -13,7 +22,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const { data, error } = await supabase
       .from('payroll_records')
-      .select('period_start, gross_salary, total_deductions, net_salary')
+      .select('period_start, gross_salary, total_deductions, net_salary, employees!payroll_records_employee_id_fkey!inner(company_id)')
+      .eq('employees.company_id', companyId)
       .gte('period_start', `${sinceStr}-01`)
 
     if (error) return res.status(500).json({ error: error.message })
@@ -29,8 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const series = Object.keys(byMonth).sort().map(k => ({ month: k, total_gross: byMonth[k].gross, total_net: byMonth[k].net, records: byMonth[k].count }))
     return res.status(200).json({ months: m, series })
   } catch (e: any) {
+    if (res.headersSent) return
     return res.status(500).json({ error: e?.message || 'Internal error' })
   }
 }
-
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Candado de autorización en cinco handlers que hoy usan `createAdminClient` sin login. El JSON de éxito no se envuelve. `createAdminClient` se queda; el filtro de empresa se escribe a mano. Webhook, preview y dashboard vivo no se tocan.

## Qué cambia

Cinco commits, un archivo (o lista pública) cada uno:

1. `pages/api/payroll/compare.ts` — `requireCompanyAccess`. Roles de nómina. Join `employees!payroll_records_employee_id_fkey!inner` (hay dos FKs a `employees`; sin el hint PostgREST 500). JSON `{ periodo, quincena, prev_periodo, current, previous, delta }`.
2. `pages/api/payroll/trend.ts` — mismo patrón. JSON `{ months, series }`.
3. `pages/api/attendance/kpis-unified.ts` — sin UUID demo ni `req.query.company_id`. `_company_id` del perfil. `employee_id` de otra empresa → 404. La UI viva sigue en `/api/attendance/kpis`.
4. `pages/api/hikvision/status/[deviceId].ts` — único cambio de JSON: no devuelve `ip_address` ni `webhook_url`. Device de otra empresa → 404. Admin sigue en `/api/admin/devices/status`.
5. `pages/api/attendance/update-schedule.ts` — POST con roles de `schedule-assignments`. Empleado de otra empresa → 404. Se quita de `getAllPublicRoutes` en `middleware.config.ts` (`middleware.ts` no usa esa lista; runtime 0).

## Trampa de super_admin

`requireCompanyAccess` deja pasar a `super_admin` con `companyId` null. Aquí: sin `companyId` de perfil → 400 `{ error: 'Company access required' }`. Nunca se lee `company_id` de query o body.

Catch: `if (res.headersSent) return` para no pisar el 401/403 de `authenticateUser`.

## Fuera de alcance

Webhook de asistencia, envelope `{ success, data }`, Zod, migrar a `createClient`, `middleware.ts`.

## Prueba en staging (por commit)

1. Sin cookie → 401 de `api-auth-fixed`.
2. Cookie empresa A → 200 con las claves congeladas.
3. Query/body `company_id` de B → datos de A o 400/404, nunca B.
4. `super_admin` sin `company_id` en perfil → 400.

Pantallas que no deben moverse: `/app/payroll` preview, `/app/attendance` dashboard, `/app/attendance/scheduling`, admin dispositivos.

Rollback: `git revert` del commit correspondiente.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86c93427-79b6-44e9-a6ab-2d67efe1b9e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86c93427-79b6-44e9-a6ab-2d67efe1b9e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

